### PR TITLE
Remove Datasource ID forceImport matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ We use the Gradle task `runExport` to run exports. The parameters are as follows
 gradle runExport \
     -PdataExportSpecFile='path/to/spec/file.json' \
     -PoutputFile='output_file.json' \
-    -PforceImports='com.className:datasource-id'
+    -PforceImports='com.className'
     -PclearDatabaseCache=true
 ```
 

--- a/src/main/java/uk/org/tombolo/DataExportEngine.java
+++ b/src/main/java/uk/org/tombolo/DataExportEngine.java
@@ -42,7 +42,7 @@ public class DataExportEngine implements ExecutionEngine{
 			importer.setDownloadUtils(downloadUtils);
 			importer.importDatasource(
 					datasourceSpec.getDatasourceId(),
-					forceImports.doesMatch(datasourceSpec.getImporterClass(), datasourceSpec.getDatasourceId())
+					forceImports.doesMatch(datasourceSpec.getImporterClass())
 			);
 		}
 

--- a/src/main/java/uk/org/tombolo/importer/ImporterMatcher.java
+++ b/src/main/java/uk/org/tombolo/importer/ImporterMatcher.java
@@ -4,39 +4,29 @@ import java.text.ParseException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * ImportMatcher.java
- * Parses a string indicating a list of class and datasource ID pairs, then matches on them.
+ * Parses a string indicating a list of classs, then matches on them.
  * The string can be in the following formats
- *   Just match one class & ID pair:
- *     uk.org.tombolo.something.ImporterClassName:datasource-id
- *   Match either one class & ID pair, or another:
- *     uk.org.tombolo.something.ImporterClassName:datasource-id,uk.org.tombolo.something.ImporterClassName2:datasource-id2
- *   Match any pair with a given class:
- *     uk.org.tombolo.something.ImporterClassName:
- *   Match any pair with a given ID:
- *     :datasource-id
- *   Match anything:
- *     :
+ *   Just match one class:
+ *     uk.org.tombolo.something.ImporterClassName
+ *   Match either one class, or another:
+ *     uk.org.tombolo.something.ImporterClassName, uk.org.tombolo.something.ImporterClassName2
  *   Match nothing:
  *     (an empty string)
  */
 public class ImporterMatcher {
-    private final List<ImporterMatcherPair> pairs;
+    private final List<String> classNames;
 
     public ImporterMatcher(String matchString) throws ParseException {
-        pairs = parseMatchString(matchString);
+        classNames = parseMatchString(matchString);
     }
 
-    private List<ImporterMatcherPair> parseMatchString(String matchString) throws ParseException {
+    private List<String> parseMatchString(String matchString) throws ParseException {
         if (null == matchString || "".equals(matchString)) { return Collections.emptyList(); }
         try {
-            return Arrays.asList(matchString.split("\\s*,\\s*")).stream().map(string -> {
-                String[] pair = string.split("\\s*:\\s*", -1); // Give us empty strings for stuff like "ClassName:"
-                return new ImporterMatcherPair(pair[0], pair[1]);
-            }).collect(Collectors.toList());
+            return Arrays.asList(matchString.split("\\s*,\\s*"));
         } catch (Exception e) {
             throw new ParseException(String.format("Could not parse importer match string: '%s'. See ImporterMatcher.java for examples.", matchString), 0);
         }
@@ -44,29 +34,12 @@ public class ImporterMatcher {
 
     /**
      * doesMatch
-     * Returns true if the given cmpClassName and cmpDatasourceId match
+     * Returns true if the given cmpClassName matches
      * the classes that we've been told to look for.
      * @param cmpClassName The className to look for
-     * @param cmpDatasourceId The datasourceId to look for
      * @return True if matches, false if does not
      */
-    public boolean doesMatch(String cmpClassName, String cmpDatasourceId) {
-        return pairs.stream().anyMatch(pair -> pair.doesMatch(cmpClassName, cmpDatasourceId));
-    }
-
-    private static class ImporterMatcherPair {
-        private final String datasourceId;
-        private final String className;
-
-        public ImporterMatcherPair(String className, String datasourceId) {
-            this.className = className;
-            this.datasourceId = datasourceId;
-        }
-
-        public boolean doesMatch(String cmpClassName, String cmpDatasourceId) {
-            return
-                    (className.length() == 0 || className.equals(cmpClassName)) &&
-                            (datasourceId.length() == 0 || datasourceId.equals(cmpDatasourceId));
-        }
+    public boolean doesMatch(String cmpClassName) {
+        return classNames.stream().anyMatch(className -> className.equals(cmpClassName));
     }
 }

--- a/src/test/java/uk/org/tombolo/DataExportEngineTest.java
+++ b/src/test/java/uk/org/tombolo/DataExportEngineTest.java
@@ -84,7 +84,7 @@ public class DataExportEngineTest extends AbstractTest {
         ).addDatasourceSpecification("uk.org.tombolo.importer.ons.LocalAuthorityImporter", "localAuthority");
 
         // And we set the clear-database flag
-        engine.execute(builder.build(), writer, new ImporterMatcher("uk.org.tombolo.importer.ons.LocalAuthorityImporter:localAuthority"));
+        engine.execute(builder.build(), writer, new ImporterMatcher("uk.org.tombolo.importer.ons.LocalAuthorityImporter"));
 
         // ...we expect the importer to ignore our fake journal and import them anyway
         assertThat(writer.toString(), hasJsonPath("$.features", hasSize(1)));

--- a/src/test/java/uk/org/tombolo/importer/ImporterMatcherTest.java
+++ b/src/test/java/uk/org/tombolo/importer/ImporterMatcherTest.java
@@ -10,53 +10,28 @@ public class ImporterMatcherTest extends AbstractTest {
 
     @Test
     public void testDoesMatchSingle() throws Exception {
-        ImporterMatcher matcher = new ImporterMatcher("com.MatchMe:match-me");
-        assertTrue(matcher.doesMatch("com.MatchMe", "match-me"));
-        assertFalse(matcher.doesMatch("com.DontMatchMe", "dont-match-me"));
+        ImporterMatcher matcher = new ImporterMatcher("com.MatchMe");
+        assertTrue(matcher.doesMatch("com.MatchMe"));
+        assertFalse(matcher.doesMatch("com.DontMatchMe"));
     }
 
     @Test
     public void testDoesMatchTwo() throws Exception {
-        ImporterMatcher matcher = new ImporterMatcher("com.MatchMe:match-me, com.MatchMeToo:match-me-too");
-        assertTrue(matcher.doesMatch("com.MatchMe", "match-me"));
-        assertTrue(matcher.doesMatch("com.MatchMeToo", "match-me-too"));
-        assertFalse(matcher.doesMatch("com.DontMatchMe", "dont-match-me"));
-    }
-
-    @Test
-    public void testDoesMatchWildcardClass() throws Exception {
-        ImporterMatcher matcher = new ImporterMatcher("com.MatchAllOfMe: , com.MatchMeToo:match-me-only");
-        assertTrue(matcher.doesMatch("com.MatchAllOfMe", "match-me"));
-        assertTrue(matcher.doesMatch("com.MatchMeToo", "match-me-only"));
-        assertFalse(matcher.doesMatch("com.MatchMeToo", "dont-match-me"));
-        assertFalse(matcher.doesMatch("com.DontMatchMe", "dont-match-me-either"));
-    }
-
-    @Test
-    public void testDoesMatchWildcardDatasource() throws Exception {
-        ImporterMatcher matcher = new ImporterMatcher("com.MatchMe:match-me, :match-all-of-me");
-        assertTrue(matcher.doesMatch("com.MatchMe", "match-me"));
-        assertTrue(matcher.doesMatch("com.MatchMeToo", "match-all-of-me"));
-        assertFalse(matcher.doesMatch("com.MatchMeToo", "dont-match-me"));
-        assertFalse(matcher.doesMatch("com.DontMatchMe", "dont-match-me-either"));
-    }
-
-    @Test
-    public void testDoesMatchWildcardAnything() throws Exception {
-        ImporterMatcher matcher = new ImporterMatcher(":");
-        assertTrue(matcher.doesMatch("com.MatchMe", "match-me"));
-        assertTrue(matcher.doesMatch("com.MatchMeToo", "match-all-of-me"));
+        ImporterMatcher matcher = new ImporterMatcher("com.MatchMe, com.MatchMeToo");
+        assertTrue(matcher.doesMatch("com.MatchMe"));
+        assertTrue(matcher.doesMatch("com.MatchMeToo"));
+        assertFalse(matcher.doesMatch("com.DontMatchMe"));
     }
 
     @Test
     public void testDoesMatchNothingWithNull() throws Exception {
         ImporterMatcher matcher = new ImporterMatcher(null);
-        assertFalse(matcher.doesMatch("com.MatchMe", "match-me"));
+        assertFalse(matcher.doesMatch("com.MatchMe"));
     }
 
     @Test
     public void testDoesMatchNothingWithEmptyString() throws Exception {
         ImporterMatcher matcher = new ImporterMatcher("");
-        assertFalse(matcher.doesMatch("com.MatchMe", "match-me"));
+        assertFalse(matcher.doesMatch("com.MatchMe"));
     }
 }


### PR DESCRIPTION
This became too much trouble, dealing with forbidding
or escaping commas/colons and the like. ClassNames
we can be reasonably sure are well-formed. Given
the use-case, clearing the data in the case of a
bug in an importer, this fulfils the brief.

---

I did have some fun writing a parser for our `class:id, class:id` format and pretty much did it, but it was a bit much for the context. We also don't want to let the tail wag the dog when it comes to forbidding various characters in the datasource ID (we do currently use commas, for instance) just so we can read that format easily.
