### PR TITLE
Manually create downloads directory

### DIFF
--- a/src/main/java/uk/org/tombolo/importer/DownloadUtils.java
+++ b/src/main/java/uk/org/tombolo/importer/DownloadUtils.java
@@ -32,6 +32,7 @@ public class DownloadUtils {
 	}
 	
 	public File getDatasourceFile(Datasource datasource) throws MalformedURLException, IOException{
+		createCacheDir();
 		File localDatasourceFile = new File(
 				tomboloDataCacheRootDirectory 
 				+ "/" + TOMBOLO_DATA_CACHE_DIRECTORY 
@@ -59,6 +60,7 @@ public class DownloadUtils {
 	}
 
 	public InputStream fetchJSONStream(URL url) throws IOException {
+		createCacheDir();
 		String urlKey = Base64.getUrlEncoder().encodeToString(url.toString().getBytes());
 		File localDatasourceFile = new File(
 				tomboloDataCacheRootDirectory
@@ -72,5 +74,9 @@ public class DownloadUtils {
 		} else {
 			return new FileInputStream(localDatasourceFile);
 		}
+	}
+
+	private void createCacheDir() throws IOException {
+		FileUtils.forceMkdir(new File(tomboloDataCacheRootDirectory + "/" + TOMBOLO_DATA_CACHE_DIRECTORY));
 	}
 }


### PR DESCRIPTION
Different file methods will create or not create parent directories automatically. FileOutputStream does not, but FileUtils.copyURLToFile does. I missed this, so now I'm remedying it by manually creating the directory in each case.
