### PR TITLE
Don't enforce one result in DB Journal

### DIFF
--- a/src/main/java/uk/org/tombolo/core/utils/DatabaseJournal.java
+++ b/src/main/java/uk/org/tombolo/core/utils/DatabaseJournal.java
@@ -20,10 +20,11 @@ public class DatabaseJournal {
 
     public static boolean journalHasEntry(DatabaseJournalEntry entry) {
         return HibernateUtil.withSession(session -> {
-            Query query = session.createQuery("from DatabaseJournalEntry where className = :className and key = :key");
+            Query query = session.createQuery("select count(*) from DatabaseJournalEntry where className = :className and key = :key");
             query.setParameter("className", entry.getClassName());
             query.setParameter("key", entry.getKey());
-            return query.uniqueResultOptional().isPresent();
+            Integer rowCount = ((Number) query.uniqueResult()).intValue();
+            return rowCount != 0;
         });
     }
 }

--- a/src/test/java/uk/org/tombolo/core/utils/DatabaseJournalTest.java
+++ b/src/test/java/uk/org/tombolo/core/utils/DatabaseJournalTest.java
@@ -17,4 +17,11 @@ public class DatabaseJournalTest extends AbstractTest {
         DatabaseJournal.addJournalEntry(new DatabaseJournalEntry("com.example.Importer", "hello"));
         assertEquals(true, DatabaseJournal.journalHasEntry(new DatabaseJournalEntry("com.example.Importer", "hello")));
     }
+
+    @Test
+    public void testMarkCachedReturnsTrueWhenCachedTwice() throws Exception {
+        DatabaseJournal.addJournalEntry(new DatabaseJournalEntry("com.example.Importer", "hello"));
+        DatabaseJournal.addJournalEntry(new DatabaseJournalEntry("com.example.Importer", "hello"));
+        assertEquals(true, DatabaseJournal.journalHasEntry(new DatabaseJournalEntry("com.example.Importer", "hello")));
+    }
 }


### PR DESCRIPTION
We can sometimes get two if jobs have been forcibly repeated.
