### PR TITLE
Fix project name to tombolo-digital-connector

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'tombolo-digital-connector'


### PR DESCRIPTION
Apparently this file is the only place you can fix the project name, which is the cleanest way of setting the built artifactId.

Set with hyphens to have consistency with other maven-style artifactIds, see `gradle.build` for examples.

Note that this is to fix https://github.com/FutureCitiesCatapult/TomboloProjectTemplate/pull/1#discussion_r83190546 which is actually caused by the artifactId defaulting to the name of the project directory (which is likely to be different on different devs' machines, CI servers, etc)
