### PR TITLE
Add Subject name field

### DIFF
--- a/src/main/java/uk/org/tombolo/field/SubjectNameField.java
+++ b/src/main/java/uk/org/tombolo/field/SubjectNameField.java
@@ -1,0 +1,33 @@
+package uk.org.tombolo.field;
+
+import org.json.simple.JSONObject;
+import uk.org.tombolo.core.Subject;
+
+/**
+ * SubjectNameField.java
+ * Returns the name of the given subject
+ */
+public class SubjectNameField implements Field, SingleValueField {
+    private final String label;
+
+    public SubjectNameField(String label) {
+        this.label = label;
+    }
+
+    @Override
+    public String valueForSubject(Subject subject) throws IncomputableFieldException {
+        return subject.getName();
+    }
+
+    @Override
+    public JSONObject jsonValueForSubject(Subject subject) throws IncomputableFieldException {
+        JSONObject obj = new JSONObject();
+        obj.put(label, valueForSubject(subject));
+        return obj;
+    }
+
+    @Override
+    public String getLabel() {
+        return label;
+    }
+}

--- a/src/test/java/uk/org/tombolo/field/SubjectNameFieldTest.java
+++ b/src/test/java/uk/org/tombolo/field/SubjectNameFieldTest.java
@@ -1,0 +1,31 @@
+package uk.org.tombolo.field;
+
+import org.json.simple.JSONObject;
+import org.junit.Before;
+import org.junit.Test;
+import uk.org.tombolo.AbstractTest;
+import uk.org.tombolo.core.Subject;
+
+import static org.junit.Assert.*;
+
+public class SubjectNameFieldTest extends AbstractTest {
+    SubjectNameField field = new SubjectNameField("aLabel");
+    Subject subject = new Subject(null, null, "theName", null);
+
+    @Test
+    public void testValueForSubject() throws Exception {
+        assertEquals("theName", field.valueForSubject(subject));
+    }
+
+    @Test
+    public void testJsonValueForSubject() throws Exception {
+        JSONObject obj = field.jsonValueForSubject(subject);
+        assertEquals(obj.size(), 1);
+        assertEquals("theName", obj.get("aLabel"));
+    }
+
+    @Test
+    public void testGetLabel() throws Exception {
+        assertEquals("aLabel", field.getLabel());
+    }
+}


### PR DESCRIPTION
Made this one in the demo session and it could come in handy for annotation and 'trust' purposes. So here it is.