### PR TITLE
De-nesting the map to nearest subject field ...

### DIFF
--- a/src/main/java/uk/org/tombolo/field/MapToNearestSubjectField.java
+++ b/src/main/java/uk/org/tombolo/field/MapToNearestSubjectField.java
@@ -1,9 +1,7 @@
 package uk.org.tombolo.field;
 
-import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import uk.org.tombolo.core.Subject;
-import uk.org.tombolo.core.TimedValueId;
 import uk.org.tombolo.core.utils.SubjectUtils;
 import uk.org.tombolo.execution.spec.FieldSpecification;
 

--- a/src/test/java/uk/org/tombolo/field/MapToNearestSubjectFieldTest.java
+++ b/src/test/java/uk/org/tombolo/field/MapToNearestSubjectFieldTest.java
@@ -33,7 +33,6 @@ public class MapToNearestSubjectFieldTest extends AbstractTest {
 
         MapToNearestSubjectField field = new MapToNearestSubjectField("aLabel", "localAuthority", 0.1d, makeFieldSpec());
         String jsonString = field.jsonValueForSubject(subject).toJSONString();
-        System.err.println(jsonString);
         JSONAssert.assertEquals("{" +
                 "  aLabel: 100.0" +
                 "}", jsonString,false);


### PR DESCRIPTION
... in order to make it true to its SingleValueField interface.

In the previous version it was returning nested value from the nested field, making our json responses even more inconsistent between fields.