### PR TITLE
Updated readme given removal of organicity folder containing examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,12 +104,12 @@ gradle runExport \
     -PclearDatabaseCache=true
 ```
 
-For example, this compares vehicle counts from road sensors to angular cost estimated in the space syntax method and outputs the results to the file `map-to-nearest-subject.json`:
+For example, this calculates the proportion of cycle traffic received at a traffic counter relative to the total traffic in a given borough  and outputs the results to the file `reaggregate-sensor-to-la.json`:
 
 ```bash
 gradle runExport \
-    -PdataExportSpecFile='src/main/resources/executions/examples/map-to-nearest-subject.json' \
-    -PoutputFile='map-to-nearest-subject.json'
+    -PdataExportSpecFile='src/main/resources/executions/examples/reaggregate-sensor-to-la.json' \
+    -PoutputFile='reaggregate-sensor-to-la.json'
 ```
 
 ### Run data catalogue


### PR DESCRIPTION
I'm not sure if the organicity folder that contains this example spec file still exists. Just wanted to run a few of the examples to check that things would be ok for tomorrow. 

I changed the readme accordingly. Please let me know if this is ok (apologies if not). 