### PR TITLE
[Info only] Hack in all datasource info

### DIFF
--- a/src/main/java/uk/org/tombolo/CatalogueExportRunner.java
+++ b/src/main/java/uk/org/tombolo/CatalogueExportRunner.java
@@ -53,7 +53,14 @@ public class CatalogueExportRunner extends AbstractRunner {
             importer.setDownloadUtils(new DownloadUtils());
             importer.configure(loadApiKeys());
 
-            return importer.getAllDatasources().stream();
+            return importer.getAllDatasources().stream().flatMap(datasource -> {
+                try {
+                    return Stream.of(importer.getDatasource(datasource.getId()));
+                } catch (Exception e) {
+                    log.warn(String.format("Could not get datasources for class %s", importerClass.toString()), e);
+                    return Stream.empty();
+                }
+            });
         } catch (Exception e) {
             log.warn(String.format("Could not get datasources for class %s", importerClass.toString()), e);
             return Stream.empty();


### PR DESCRIPTION
Because many of the importers (e.g. ONSCensus) only really populate datasources when called with `getDatasource`, we iterate over all the datasources again and call `getDatasource` with their ids to get a fuller picture.

Not the right way of doing it, suggest not merging this in and finding a better way, but if you need to run the job in the mean time