### PR TITLE
Implementation of configurable importer thresholds

### DIFF
--- a/src/main/java/uk/org/tombolo/importer/AbstractGeotoolsDataStoreImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/AbstractGeotoolsDataStoreImporter.java
@@ -206,7 +206,7 @@ public abstract class AbstractGeotoolsDataStoreImporter extends AbstractImporter
 
     private void flushBufferIfRequired(){
         int bufferSize = timedValueBuffer.size() + fixedValueBuffer.size() + subjectBuffer.size();
-        if (bufferSize > BUFFER_THRESHOLD) {
+        if (bufferSize > getCombinedBufferSize()) {
             flushBuffer();
         }
     }

--- a/src/main/java/uk/org/tombolo/importer/AbstractImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/AbstractImporter.java
@@ -16,7 +16,7 @@ import java.util.Properties;
 
 public abstract class AbstractImporter implements Importer {
 	// Flushing threshold for TimedValue/FixedValue/Subject save buffers
-	protected static final Integer BUFFER_THRESHOLD = 10000;
+	private static final Integer BUFFER_THRESHOLD = 10000;
 
 	protected List<String> datasourceIds;
 	protected List<String> geographyLabels;
@@ -206,5 +206,25 @@ public abstract class AbstractImporter implements Importer {
 
 	public int getTimedValueCount() {
 		return timedValueCount;
+	}
+
+	@Override
+	public int getCombinedBufferSize() {
+		return BUFFER_THRESHOLD;
+	}
+
+	@Override
+	public int getSubjectBufferSize() {
+		return BUFFER_THRESHOLD;
+	}
+
+	@Override
+	public int getFixedValueBufferSize() {
+		return BUFFER_THRESHOLD;
+	}
+
+	@Override
+	public int getTimedValueBufferSize() {
+		return BUFFER_THRESHOLD;
 	}
 }

--- a/src/main/java/uk/org/tombolo/importer/Importer.java
+++ b/src/main/java/uk/org/tombolo/importer/Importer.java
@@ -85,4 +85,9 @@ public interface Importer {
 	int getSubjectCount();
 	int getFixedValueCount();
 	int getTimedValueCount();
+
+	int getCombinedBufferSize();
+	int getTimedValueBufferSize();
+	int getFixedValueBufferSize();
+	int getSubjectBufferSize();
 }

--- a/src/main/java/uk/org/tombolo/importer/dft/AccessibilityImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/dft/AccessibilityImporter.java
@@ -160,7 +160,7 @@ public class AccessibilityImporter extends AbstractDFTImporter implements Import
             }
 
             // Extract timed values
-            excelUtils.extractAndSaveTimedValues(sheet, this, timedValueExtractors, BUFFER_THRESHOLD);
+            excelUtils.extractAndSaveTimedValues(sheet, this, timedValueExtractors);
         }
     }
 

--- a/src/main/java/uk/org/tombolo/importer/dft/TrafficCountImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/dft/TrafficCountImporter.java
@@ -52,6 +52,8 @@ public class TrafficCountImporter extends AbstractDFTImporter implements Importe
 	private static final int STARTJUNCTION_INDEX = 10;
 	private static final int ENDJUNCTION_INDEX = 11;
 
+	private static final int TIMED_VALUE_BUFFER_SIZE = 100000;
+
 	protected enum DatasourceId {
 		trafficVolume(new DataSourceID(
 				"trafficVolume",
@@ -291,6 +293,11 @@ public class TrafficCountImporter extends AbstractDFTImporter implements Importe
 	}
 
 	@Override
+	public int getTimedValueBufferSize() {
+		return TIMED_VALUE_BUFFER_SIZE;
+	}
+
+	@Override
 	public Datasource getDatasource(String datasourceIdString) throws Exception {
 		DatasourceId datasourceId = DatasourceId.valueOf(datasourceIdString);
 
@@ -399,7 +406,7 @@ public class TrafficCountImporter extends AbstractDFTImporter implements Importe
 						break;
 				}
 
-				if (timedValueBuffer.size() > BUFFER_THRESHOLD)
+				if (timedValueBuffer.size() > getTimedValueBufferSize())
 					saveAndClearTimedValueBuffer(timedValueBuffer);
 
 			}

--- a/src/main/java/uk/org/tombolo/importer/londondatastore/WalkingCyclingBoroughImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/londondatastore/WalkingCyclingBoroughImporter.java
@@ -117,7 +117,7 @@ public class WalkingCyclingBoroughImporter extends AbstractLondonDatastoreImport
                 new RowCellExtractor(40, Cell.CELL_TYPE_NUMERIC)
         ));
         Sheet walkSheet = workbook.getSheetAt(1);
-        excelUtils.extractAndSaveTimedValues(walkSheet, this, walk5xWeekExtractors, BUFFER_THRESHOLD);
+        excelUtils.extractAndSaveTimedValues(walkSheet, this, walk5xWeekExtractors);
 
         // Extract cycling
         ConstantExtractor cycle1xWeekAttributeLabelExtractor = new ConstantExtractor(AttributeId.cycle1xWeek.name());
@@ -155,7 +155,7 @@ public class WalkingCyclingBoroughImporter extends AbstractLondonDatastoreImport
                 new RowCellExtractor(38, Cell.CELL_TYPE_NUMERIC)
         ));
         Sheet cycleSheet = workbook.getSheetAt(2);
-        excelUtils.extractAndSaveTimedValues(cycleSheet, this, cycle1xWeekExtractors, BUFFER_THRESHOLD);
+        excelUtils.extractAndSaveTimedValues(cycleSheet, this, cycle1xWeekExtractors);
     }
 
     private Attribute getAttribute(AttributeId attributeId){

--- a/src/main/java/uk/org/tombolo/importer/ons/ONSCensusImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/ons/ONSCensusImporter.java
@@ -55,11 +55,18 @@ public class ONSCensusImporter extends AbstractONSImporter implements Importer{
 	private static final String ONS_DATASET_BASE_URL = "http://data.statistics.gov.uk/ons/datasets/";
 	
 	private static final LocalDateTime CENSUS_2011_DATE_TIME = LocalDateTime.of(2011,12,31,23,59,59);
-	
+
+	private static final int TIMED_VALUE_BUFFER_SIZE = 100000;
+
 	private Logger log = LoggerFactory.getLogger(ONSCensusImporter.class);
 
 	public ONSCensusImporter(Config config) throws IOException, ParseException, ConfigurationException {
 		super(config);
+	}
+
+	@Override
+	public int getTimedValueBufferSize() {
+		return TIMED_VALUE_BUFFER_SIZE;
 	}
 
 	@Override
@@ -180,7 +187,7 @@ public class ONSCensusImporter extends AbstractONSImporter implements Importer{
 									timedValueBuffer.add(tv);
 
 									// Flushing buffer
-									if (timedValueBuffer.size() % BUFFER_THRESHOLD == 0){
+									if (timedValueBuffer.size() % getTimedValueBufferSize() == 0){
 										saveAndClearTimedValueBuffer(timedValueBuffer);
 									}
 								}								

--- a/src/main/java/uk/org/tombolo/importer/ons/ONSWagesImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/ons/ONSWagesImporter.java
@@ -176,7 +176,7 @@ public class ONSWagesImporter extends AbstractONSImporter implements Importer{
                 }
 
                 Sheet sheet = workbook.getSheet(sheetName);
-                excelUtils.extractAndSaveTimedValues(sheet,this,extractors,BUFFER_THRESHOLD);
+                excelUtils.extractAndSaveTimedValues(sheet,this,extractors);
             }
         }
     }

--- a/src/main/java/uk/org/tombolo/importer/phe/AdultObesityImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/phe/AdultObesityImporter.java
@@ -89,7 +89,7 @@ public class AdultObesityImporter extends AbstractPheImporter implements Importe
                     timestampExtractor,
                     valueExtractor));
         }
-        excelUtils.extractAndSaveTimedValues(sheet, this, timedValueExtractors, BUFFER_THRESHOLD);
+        excelUtils.extractAndSaveTimedValues(sheet, this, timedValueExtractors);
     }
 
     private List<Attribute> getAttributes() {

--- a/src/main/java/uk/org/tombolo/importer/phe/ChildhoodObesityImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/phe/ChildhoodObesityImporter.java
@@ -115,7 +115,7 @@ public class ChildhoodObesityImporter extends AbstractPheImporter implements Imp
             }
 
             // Extract timed values
-            excelUtils.extractAndSaveTimedValues(sheet, this, timedValueExtractors, BUFFER_THRESHOLD);
+            excelUtils.extractAndSaveTimedValues(sheet, this, timedValueExtractors);
         }
     }
 

--- a/src/main/java/uk/org/tombolo/importer/utils/ExcelUtils.java
+++ b/src/main/java/uk/org/tombolo/importer/utils/ExcelUtils.java
@@ -26,7 +26,7 @@ public class ExcelUtils {
 		return WorkbookFactory.create(is);
 	}
 
-	public void extractAndSaveTimedValues(Sheet sheet, Importer importer, List<TimedValueExtractor> extractors, int timedValueBufferSize){
+	public void extractAndSaveTimedValues(Sheet sheet, Importer importer, List<TimedValueExtractor> extractors){
 		int valueCount = 0;
 		List<TimedValue> timedValueBuffer = new ArrayList<>();
 
@@ -40,7 +40,7 @@ public class ExcelUtils {
 					TimedValue timedValue = extractor.extract();
 					timedValueBuffer.add(timedValue);
 					valueCount++;
-					if (valueCount % timedValueBufferSize == 0) {
+					if (valueCount % importer.getTimedValueBufferSize() == 0) {
 						// Buffer is full ... we write values to db
 						importer.saveAndClearTimedValueBuffer(timedValueBuffer);
 					}


### PR DESCRIPTION
Having a single buffer size for all importers can lead to efficiency issue for large datasets, such as traffic counts and census.

I included buffer-sizes into the Importer interface to give us more flexibility to tune different importers.

Updated traffic counts and census to use a larger buffer than default.