### PR TITLE
Traffic air quality example

### DIFF
--- a/src/main/java/uk/org/tombolo/field/aggregation/GeographicAggregationField.java
+++ b/src/main/java/uk/org/tombolo/field/aggregation/GeographicAggregationField.java
@@ -4,6 +4,8 @@ import org.apache.commons.math3.stat.descriptive.moment.Mean;
 import org.apache.commons.math3.stat.descriptive.summary.Sum;
 import org.apache.commons.math3.util.MathArrays;
 import org.apache.commons.math3.util.ResizableDoubleArray;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.org.tombolo.core.Subject;
 import uk.org.tombolo.core.SubjectType;
 import uk.org.tombolo.core.utils.SubjectTypeUtils;
@@ -26,6 +28,8 @@ import java.util.Map;
  * So far, `sum` and `mean` are implemented.
  */
 public class GeographicAggregationField extends AbstractField implements Field, SingleValueField {
+    private static Logger log = LoggerFactory.getLogger(GeographicAggregationField.class);
+
     public static enum AggregationFunction {sum, mean}
     private final String aggregationSubjectProvider;
     private final String aggregationSubjectType;
@@ -69,7 +73,9 @@ public class GeographicAggregationField extends AbstractField implements Field, 
             try {
                 doubles.addElement(Double.parseDouble(field.valueForSubject(subject, true)));
             } catch (IncomputableFieldException e) {
-                throw new IncomputableFieldException("Aggregator item failed to compute: " + e.getMessage(), e);
+                log.warn("Incomputable field not included in aggregation for subject {} ({})",
+                        subject.getName(),
+                        subject.getId());
             }
         }
 

--- a/src/main/java/uk/org/tombolo/importer/lac/LAQNImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/lac/LAQNImporter.java
@@ -200,7 +200,7 @@ public class LAQNImporter extends AbstractImporter implements Importer{
     private Geometry shape(String latitude, String longitude) {
         GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), Subject.SRID);
         return geometryFactory
-                .createPoint(new Coordinate(Double.parseDouble(latitude), Double.parseDouble(longitude)));
+                .createPoint(new Coordinate(Double.parseDouble(longitude), Double.parseDouble(latitude)));
     }
 
     private String importerURL(String area, String year) {

--- a/src/main/resources/executions/examples/london-cycle-traffic-air-quality.json
+++ b/src/main/resources/executions/examples/london-cycle-traffic-air-quality.json
@@ -25,6 +25,7 @@
         "geographyScope" : ["London"]
       },
       {
+        // Importer for air quality
         "importerClass" : "uk.org.tombolo.importer.lac.LAQNImporter",
         "datasourceId": "airQualityControl"
       }
@@ -35,13 +36,12 @@
         "label": "Nitrogen Dioxide",
         "aggregationSubjectProvider": "erg.kcl.ac.uk",
         "aggregationSubjectType": "airQualityControl",
-        "aggregationFunction": "avg",
+        "aggregationFunction": "mean",
         "fieldSpecification": {
           "fieldClass": "uk.org.tombolo.field.value.LatestValueField",
-          "label": "CountPedalCycles",
           "attribute": {
             "providerLabel" : "erg.kcl.ac.uk",
-            "attributeLabel" : "NO2 40 ug/m3 as an annual mean"
+            "attributeLabel" : "NO2 40 ug/m3 as an annual me"
           }
         }
       },

--- a/src/main/resources/executions/examples/london-no2.json
+++ b/src/main/resources/executions/examples/london-no2.json
@@ -1,0 +1,28 @@
+{
+  "dataset": {
+    "subjects": [
+      {
+        "subjectType": "airQualityControl",
+        "provider": "erg.kcl.ac.uk"
+      }
+    ],
+    "datasources": [
+      {
+        "importerClass": "uk.org.tombolo.importer.lac.LAQNImporter",
+        "datasourceId": "airQualityControl"
+      }
+    ],
+    "fields": [
+      {
+        "fieldClass": "uk.org.tombolo.field.value.LatestValueField",
+        "label": "Anual NO2",
+        "attribute": {
+          "providerLabel": "erg.kcl.ac.uk",
+          "attributeLabel": "NO2 40 ug/m3 as an annual me"
+        }
+      }
+    ]
+  },
+  "exporter" : "uk.org.tombolo.exporter.GeoJsonExporter"
+}
+

--- a/src/test/java/uk/org/tombolo/lac/LAQNImporterTest.java
+++ b/src/test/java/uk/org/tombolo/lac/LAQNImporterTest.java
@@ -126,7 +126,10 @@ public class LAQNImporterTest extends AbstractTest {
 
         assertEquals("BG1", subjects.get(0).getLabel());
         assertEquals("Barking and Dagenham - Rush Green", subjects.get(0).getName());
-
+        // Testing x coordinate (longitude)
+        assertEquals(0.177891, subjects.get(0).getShape().getCoordinate().getOrdinate(0), 0.0001);
+        // Testing y coordinate (latitude)
+        assertEquals(51.563752, subjects.get(0).getShape().getCoordinate().getOrdinate(1), 0.0001);
     }
 
     @Test


### PR DESCRIPTION
Added example execution for combining traffic counts.

At the same time I fixed two bugs:

- Fixed an error in the LAQN importer where latitudes and longitudes were mixed up. 
- Relaxed the aggregation of missing values from throwing an exception to raising a warning.