### PR TITLE
Tutorial only based on London data

### DIFF
--- a/src/main/java/uk/org/tombolo/execution/DataExportEngine.java
+++ b/src/main/java/uk/org/tombolo/execution/DataExportEngine.java
@@ -70,7 +70,7 @@ public class DataExportEngine implements ExecutionEngine {
 		for (Field field : fields) {
 			if (field instanceof ModellingField) {
 				// This is a predefined field and hence we need to import the appropriate datasources
-				for (DatasourceRecipe datasourceRecipe : ((ModellingField) field).getDatasourceRecipes()) {
+				for (DatasourceRecipe datasourceRecipe : ((ModellingField) field).getDatasources()) {
 					importDatasource(forceImports, datasourceRecipe);
 				}
 			}

--- a/src/main/java/uk/org/tombolo/field/modelling/ModellingField.java
+++ b/src/main/java/uk/org/tombolo/field/modelling/ModellingField.java
@@ -11,5 +11,5 @@ import java.util.List;
  */
 public interface ModellingField extends Field {
 
-    public List<DatasourceRecipe> getDatasourceRecipes();
+    public List<DatasourceRecipe> getDatasources();
 }

--- a/src/main/java/uk/org/tombolo/field/modelling/SingleValueModellingField.java
+++ b/src/main/java/uk/org/tombolo/field/modelling/SingleValueModellingField.java
@@ -3,6 +3,9 @@ package uk.org.tombolo.field.modelling;
 import uk.org.tombolo.core.Subject;
 import uk.org.tombolo.field.IncomputableFieldException;
 import uk.org.tombolo.field.SingleValueField;
+import uk.org.tombolo.recipe.DatasourceRecipe;
+
+import java.util.List;
 
 /**
  * This is an extension of the {@link BasicModellingField} in order to support the use of modelling fields in
@@ -11,8 +14,8 @@ import uk.org.tombolo.field.SingleValueField;
  */
 public class SingleValueModellingField extends BasicModellingField {
 
-    public SingleValueModellingField(String label, String recipe) {
-        super(label, recipe);
+    public SingleValueModellingField(String label, String recipe, List<DatasourceRecipe> datasources) {
+        super(label, recipe, datasources);
     }
 
     @Override

--- a/src/main/resources/executions/examples/london-cycle-traffic-air-quality-lsoa-backoff.json
+++ b/src/main/resources/executions/examples/london-cycle-traffic-air-quality-lsoa-backoff.json
@@ -72,7 +72,14 @@
         "fields": [
           {
             "fieldClass": "uk.org.tombolo.field.modelling.SingleValueModellingField",
-            "recipe": "transport/traffic-counts-aggregated-bicycles-to-cars-ratio"
+            "recipe": "transport/traffic-counts-aggregated-bicycles-to-cars-ratio",
+            "datasources": [
+              {
+                "importerClass" : "uk.org.tombolo.importer.dft.TrafficCountImporter",
+                "datasourceId" : "trafficCounts",
+                "geographyScope" : ["London"]
+              }
+            ]
           },
           {
             "fieldClass": "uk.org.tombolo.field.aggregation.MapToContainingSubjectField",
@@ -82,7 +89,14 @@
             },
             "field": {
               "fieldClass": "uk.org.tombolo.field.modelling.SingleValueModellingField",
-              "recipe": "transport/traffic-counts-aggregated-bicycles-to-cars-ratio"
+              "recipe": "transport/traffic-counts-aggregated-bicycles-to-cars-ratio",
+              "datasources": [
+                {
+                  "importerClass" : "uk.org.tombolo.importer.dft.TrafficCountImporter",
+                  "datasourceId" : "trafficCounts",
+                  "geographyScope" : ["London"]
+                }
+              ]
             }
           },
           {
@@ -93,7 +107,14 @@
             },
             "field": {
               "fieldClass": "uk.org.tombolo.field.modelling.SingleValueModellingField",
-              "recipe": "transport/traffic-counts-aggregated-bicycles-to-cars-ratio"
+              "recipe": "transport/traffic-counts-aggregated-bicycles-to-cars-ratio",
+              "datasources": [
+                {
+                  "importerClass" : "uk.org.tombolo.importer.dft.TrafficCountImporter",
+                  "datasourceId" : "trafficCounts",
+                  "geographyScope" : ["London"]
+                }
+              ]
             }
           }
         ]

--- a/src/main/resources/executions/examples/london-cycle-traffic-air-quality-lsoa-modelling.json
+++ b/src/main/resources/executions/examples/london-cycle-traffic-air-quality-lsoa-modelling.json
@@ -38,7 +38,14 @@
       {
         "fieldClass": "uk.org.tombolo.field.modelling.SingleValueModellingField",
         "label": "BicycleFraction",
-        "recipe": "transport/traffic-counts-aggregated-bicycles-to-cars-ratio"
+        "recipe": "transport/traffic-counts-aggregated-bicycles-to-cars-ratio",
+        "datasources": [
+          {
+            "importerClass" : "uk.org.tombolo.importer.dft.TrafficCountImporter",
+            "datasourceId" : "trafficCounts",
+            "geographyScope" : ["London"]
+          }
+        ]
       }
     ]
   },

--- a/src/test/java/uk/org/tombolo/field/modelling/BasicModellingFieldTest.java
+++ b/src/test/java/uk/org/tombolo/field/modelling/BasicModellingFieldTest.java
@@ -11,13 +11,14 @@ import uk.org.tombolo.core.SubjectType;
 import uk.org.tombolo.recipe.DatasourceRecipe;
 import uk.org.tombolo.importer.ons.AbstractONSImporter;
 
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
 public class BasicModellingFieldTest extends AbstractTest {
     private static final String RECIPE = "ModellingFieldTest";
-    BasicModellingField field = new BasicModellingField("test_label", RECIPE);
+    BasicModellingField field = new BasicModellingField("test_label", RECIPE, null);
 
     Subject subject;
 
@@ -34,7 +35,7 @@ public class BasicModellingFieldTest extends AbstractTest {
     @Test
     public void getDatasourceSpecifications() throws Exception {
 
-        List<DatasourceRecipe> datasources = field.getDatasourceRecipes();
+        List<DatasourceRecipe> datasources = field.getDatasources();
 
         assertEquals(2, datasources.size());
 
@@ -45,6 +46,19 @@ public class BasicModellingFieldTest extends AbstractTest {
         DatasourceRecipe ds2 = datasources
                 .stream().filter(e -> e.getDatasourceId().equals("qs103ew")).findAny().orElse(null);
         assertEquals("uk.org.tombolo.importer.ons.CensusImporter", ds2.getImporterClass());
+    }
+
+    @Test
+    public void testGetDatasouceSpecificationOverride() throws Exception {
+        BasicModellingField field = new BasicModellingField(
+                "test_label",
+                RECIPE,
+                Collections.singletonList(new DatasourceRecipe(
+                        "uk.org.tombolo.importer.ons.OaImporter",
+                        "lsoa",
+                        null, null, null)));
+
+        assertEquals(1, field.getDatasources().size());
     }
 
     @Test


### PR DESCRIPTION
- Including support for overriding the datasources of a modelling field. 
- Updating the tutorial modelling and backoff examples so that they work only with london data.