### PR TITLE
fix for gradle failing for having empty string as a default value for…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ task runExport(dependsOn: ['classes'], type: JavaExec) {
 		def argumentsSet = project.hasProperty('dataExportSpecFile') && project.hasProperty('outputFile');
 		if (!argumentsSet) throw new GradleException('Required properties not specified. See the README.')
 		if (!project.hasProperty('clearDatabaseCache')) { ext.clearDatabaseCache = false }
-		if (!project.hasProperty('forceImports')) { ext.forceImports = "" }
+		if (!project.hasProperty('forceImports')) { ext.forceImports = " " }
 
 		args(dataExportSpecFile, outputFile, forceImports, clearDatabaseCache)
 	}

--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ task runExport(dependsOn: ['classes'], type: JavaExec) {
 		def argumentsSet = project.hasProperty('dataExportSpecFile') && project.hasProperty('outputFile');
 		if (!argumentsSet) throw new GradleException('Required properties not specified. See the README.')
 		if (!project.hasProperty('clearDatabaseCache')) { ext.clearDatabaseCache = false }
-		if (!project.hasProperty('forceImports')) { ext.forceImports = " " }
+		if (!project.hasProperty('forceImports')) { ext.forceImports = "None" }
 
 		args(dataExportSpecFile, outputFile, forceImports, clearDatabaseCache)
 	}

--- a/src/main/java/uk/org/tombolo/DataExportRunner.java
+++ b/src/main/java/uk/org/tombolo/DataExportRunner.java
@@ -45,7 +45,7 @@ public class DataExportRunner extends AbstractRunner {
             engine.execute(
                     getSpecification(executionSpecPath),
                     writer,
-                    new ImporterMatcher(forceImports)
+                    new ImporterMatcher(forceImports.trim())
             );
         } catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/uk/org/tombolo/importer/ImporterMatcher.java
+++ b/src/main/java/uk/org/tombolo/importer/ImporterMatcher.java
@@ -24,7 +24,7 @@ public class ImporterMatcher {
     }
 
     private List<String> parseMatchString(String matchString) throws ParseException {
-        if (null == matchString || "".equals(matchString)) { return Collections.emptyList(); }
+        if (null == matchString || "None".equals(matchString) || "".equals(matchString)) { return Collections.emptyList(); }
         try {
             return Arrays.asList(matchString.split("\\s*,\\s*"));
         } catch (Exception e) {


### PR DESCRIPTION
#361 on windows having default value for forceimports are "" string was failing, the fix is to provide a space in between and then trim it out in DataExportRunner before passing it to ImporterMatcher
