### PR TITLE
added functionality to pass recipe as string

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -96,12 +96,16 @@ task runExport(dependsOn: ['classes'], type: JavaExec) {
 		systemProperty("databasePassword", databasePassword)
 		systemProperty("environment", "export")
 
-		def argumentsSet = project.hasProperty('dataExportSpecFile') && project.hasProperty('outputFile');
+		def argumentsSet = (project.hasProperty('dataExportSpecFile') || project.hasProperty('dataExportSpec')) && project.hasProperty('outputFile');
 		if (!argumentsSet) throw new GradleException('Required properties not specified. See the README.')
+		def requiredOne = project.hasProperty('dataExportSpecFile') && project.hasProperty('dataExportSpec');
+		if (requiredOne) throw new GradleException('From dataExportSpecFile and dataExportSpec only one is required. See the README.')
 		if (!project.hasProperty('clearDatabaseCache')) { ext.clearDatabaseCache = false }
 		if (!project.hasProperty('forceImports')) { ext.forceImports = "None" }
+		if (!project.hasProperty('dataExportSpecFile')) { ext.dataExportSpecFile = "None" }
+		if (!project.hasProperty('dataExportSpec')) { ext.dataExportSpec = "None" }
 
-		args(dataExportSpecFile, outputFile, forceImports, clearDatabaseCache)
+		args(dataExportSpecFile, outputFile, forceImports, clearDatabaseCache, dataExportSpec)
 	}
 }
 

--- a/src/main/java/uk/org/tombolo/AbstractRunner.java
+++ b/src/main/java/uk/org/tombolo/AbstractRunner.java
@@ -51,6 +51,10 @@ public abstract class AbstractRunner {
         return RecipeDeserializer.fromJsonFile(file, DataExportRecipe.class);
     }
 
+    protected static DataExportRecipe getSpecificationFromString(String specification) throws IOException {
+        return RecipeDeserializer.fromJsonString(specification, DataExportRecipe.class);
+    }
+
     protected static DownloadUtils initialiseDowloadUtils() throws ConfigurationException {
         Properties properties = loadProperties(SYSTEM_PROPERTIES_PROPERTY_NAME, SYSTEM_PROPERTIES_FILENAME);
         log.info("Setting file download cache: {}", properties.getProperty(FILE_DOWNLOAD_CACHE));

--- a/src/main/java/uk/org/tombolo/recipe/RecipeDeserializer.java
+++ b/src/main/java/uk/org/tombolo/recipe/RecipeDeserializer.java
@@ -19,6 +19,10 @@ public class RecipeDeserializer {
         return fromJson(FileUtils.readFileToString(jsonFile), returningClass);
     }
 
+    public static <T> T fromJsonString(String json, Class<T> returningClass) throws IOException {
+        return fromJson(json, returningClass);
+    }
+
     private static class FieldDeserializer implements JsonDeserializer<FieldRecipe> {
         @Override
         public FieldRecipe deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {


### PR DESCRIPTION
### Description
Added the functionality to pass recipe as string, this is useful when user would want to run recipes directly from python notebook without saving the recipe.
It would also work, if user pass the recipe as a string from terminal.

### Checklist
None
