### PR TITLE
Leave config file only for general importers

### DIFF
--- a/src/main/java/uk/org/tombolo/CatalogueExportRunner.java
+++ b/src/main/java/uk/org/tombolo/CatalogueExportRunner.java
@@ -5,12 +5,9 @@ import org.reflections.Reflections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.org.tombolo.core.Datasource;
-import uk.org.tombolo.core.Provider;
-import uk.org.tombolo.core.SubjectType;
-import uk.org.tombolo.importer.Config;
 import uk.org.tombolo.importer.Importer;
 
-import java.io.*;
+import java.io.File;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 import java.nio.file.Files;
@@ -68,12 +65,10 @@ public class CatalogueExportRunner extends AbstractRunner {
     public Importer getImporter(Class<? extends Importer> importerClass) {
         Importer importer = null;
         try {
-            Config DEFAULT_CONFIG = new Config.Builder(0, "", "", "",
-                    new SubjectType(new Provider("", ""), "", "")).build();
 
             Class<?> theClass = Class.forName(importerClass.getCanonicalName());
-            Constructor<?> constructor = theClass.getConstructor(Config.class);
-            importer = (Importer) constructor.newInstance(DEFAULT_CONFIG);
+            Constructor<?> constructor = theClass.getConstructor();
+            importer = (Importer) constructor.newInstance();
             importer.setDownloadUtils(initialiseDowloadUtils());
             importer.configure(loadApiKeys());
         } catch (Exception e) {

--- a/src/main/java/uk/org/tombolo/core/Datasource.java
+++ b/src/main/java/uk/org/tombolo/core/Datasource.java
@@ -1,7 +1,6 @@
 package uk.org.tombolo.core;
 
 import com.google.gson.stream.JsonWriter;
-import uk.org.tombolo.importer.Config;
 import uk.org.tombolo.importer.Importer;
 
 import java.io.IOException;
@@ -68,11 +67,9 @@ public class Datasource {
 		writer.name("url").value(datasourceSpec.getUrl());
 
 		// Adding provider in order to have it in Catalogue, we may need to review this in future
-		Config DEFAULT_CONFIG = new Config.Builder(0, "", "", "",
-				new SubjectType(new Provider("", ""), "", "")).build();
 		Class<?> theClass = Class.forName(datasourceSpec.getImporterClass().getCanonicalName());
-		Constructor<?> constructor = theClass.getConstructor(Config.class);
-		Importer importer = (Importer) constructor.newInstance(DEFAULT_CONFIG);
+		Constructor<?> constructor = theClass.getConstructor();
+		Importer importer = (Importer) constructor.newInstance();
 		writer.name("provider");
 		importer.getProvider().writeJSON(writer);
 

--- a/src/main/java/uk/org/tombolo/execution/DataExportEngine.java
+++ b/src/main/java/uk/org/tombolo/execution/DataExportEngine.java
@@ -102,13 +102,13 @@ public class DataExportEngine implements ExecutionEngine {
 	}
 
 	private Importer initialiseImporter(String importerClass, String configFile) throws Exception {
-		Config importerConfiguration = null;
-		if (configFile != null && !"".equals(configFile)) {
-			importerConfiguration = ConfigUtils.loadConfig(
+		if (configFile != null) {
+			Config importerConfiguration = ConfigUtils.loadConfig(
 					AbstractRunner.loadProperties("Configuration file", configFile));
+			return (Importer) Class.forName(importerClass).getDeclaredConstructor(Config.class).newInstance(importerConfiguration);
 
 		}
-		return (Importer) Class.forName(importerClass).getDeclaredConstructor(Config.class).newInstance(importerConfiguration);
+		return (Importer) Class.forName(importerClass).getDeclaredConstructor().newInstance();
 	}
 
 	/**

--- a/src/main/java/uk/org/tombolo/importer/AbstractGeotoolsDataStoreImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/AbstractGeotoolsDataStoreImporter.java
@@ -44,10 +44,6 @@ public abstract class AbstractGeotoolsDataStoreImporter extends AbstractImporter
     private List<TimedValue> timedValueBuffer = new ArrayList<>();
     private List<FixedValue> fixedValueBuffer = new ArrayList<>();
 
-    public AbstractGeotoolsDataStoreImporter(Config config) {
-        super(config);
-    }
-
     private List<Subject> subjectBuffer = new ArrayList<>();
 
     /**

--- a/src/main/java/uk/org/tombolo/importer/AbstractImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/AbstractImporter.java
@@ -20,7 +20,6 @@ public abstract class AbstractImporter implements Importer {
 	protected List<String> datasourceIds;
 	protected List<String> geographyLabels;
 	protected List<String> temporalLabels;
-	protected Config config;
 	protected List<SubjectRecipe> subjectRecipes;
 
 	protected final static String DEFAULT_GEOGRAPHY = "all";
@@ -34,13 +33,10 @@ public abstract class AbstractImporter implements Importer {
 	protected Properties properties = new Properties();
 	protected DownloadUtils downloadUtils;
 
-	public AbstractImporter() {}
-
-	public AbstractImporter(Config config) {
+	public AbstractImporter() {
 		datasourceIds = Collections.emptyList();
 		geographyLabels = Collections.singletonList(DEFAULT_GEOGRAPHY);
 		temporalLabels = Collections.singletonList(DEFAULT_TEMPORAL);
-		this.config = config;
 	}
 
 	@Override
@@ -66,8 +62,6 @@ public abstract class AbstractImporter implements Importer {
 	public void setDownloadUtils(DownloadUtils downloadUtils){
 		this.downloadUtils = downloadUtils;
 	}
-
-	public void setConfig(Config config) { this.config = config; }
 
 	/**
 	 * Loads the data-source identified by datasourceId into the underlying data store

--- a/src/main/java/uk/org/tombolo/importer/AbstractOaImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/AbstractOaImporter.java
@@ -11,15 +11,11 @@ import java.util.List;
 
 public abstract class AbstractOaImporter extends AbstractImporter {
 
-    public AbstractOaImporter(Config config) {
-        super(config);
-    }
-
     @Override
     public void importDatasource(@Nonnull String datasourceId, List<String> geographyScope, List<String> temporalScope,
                                  List<String> datasourceLocation, @Nonnull List<SubjectRecipe> subjectRecipes, Boolean force)
                                 throws Exception {
-        OaImporter oaImporter = new OaImporter(config);
+        OaImporter oaImporter = new OaImporter();
         oaImporter.setDownloadUtils(downloadUtils);
         for (SubjectRecipe subjectRecipe : subjectRecipes) {
             if (!DatabaseJournal.journalHasEntry(JournalEntryUtils.getJournalEntryForDatasourceId(

--- a/src/main/java/uk/org/tombolo/importer/GeneralImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/GeneralImporter.java
@@ -1,0 +1,11 @@
+package uk.org.tombolo.importer;
+
+public abstract class GeneralImporter extends AbstractImporter{
+    protected Config config;
+
+    public GeneralImporter(Config config) {
+        this.config = config;
+    }
+
+    public void setConfig(Config config) { this.config = config; }
+}

--- a/src/main/java/uk/org/tombolo/importer/dclg/AbstractDCLGImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/dclg/AbstractDCLGImporter.java
@@ -2,15 +2,10 @@ package uk.org.tombolo.importer.dclg;
 
 import uk.org.tombolo.core.Provider;
 import uk.org.tombolo.importer.AbstractOaImporter;
-import uk.org.tombolo.importer.Config;
 
 public abstract class AbstractDCLGImporter extends AbstractOaImporter {
     public static final Provider PROVIDER
             = new Provider("uk.gov.dclg", "Department for Communities and Local Government");
-
-    public AbstractDCLGImporter(Config config) {
-        super(config);
-    }
 
     @Override
     public Provider getProvider() {

--- a/src/main/java/uk/org/tombolo/importer/dclg/IMDImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/dclg/IMDImporter.java
@@ -5,7 +5,6 @@ import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 import uk.org.tombolo.core.*;
 import uk.org.tombolo.core.utils.SubjectUtils;
-import uk.org.tombolo.importer.Config;
 import uk.org.tombolo.importer.ons.OaImporter;
 
 import java.io.BufferedReader;
@@ -46,8 +45,7 @@ public class IMDImporter extends AbstractDCLGImporter {
             = "https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/467774/" +
             "File_7_ID_2015_All_ranks__deciles_and_scores_for_the_Indices_of_Deprivation__and_population_denominators.csv";
 
-    public IMDImporter(Config config) {
-        super(config);
+    public IMDImporter() {
         datasourceIds = stringsFromEnumeration(DatasourceId.class);
         geographyLabels = stringsFromEnumeration(GeographyLabel.class);
         temporalLabels = stringsFromEnumeration(TemporalLabel.class);

--- a/src/main/java/uk/org/tombolo/importer/dfe/AbstractDfEImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/dfe/AbstractDfEImporter.java
@@ -2,17 +2,12 @@ package uk.org.tombolo.importer.dfe;
 
 import uk.org.tombolo.core.Provider;
 import uk.org.tombolo.importer.AbstractImporter;
-import uk.org.tombolo.importer.Config;
 
 /**
  * Abstract class for the school importer indicating the provider
  */
 public abstract class AbstractDfEImporter extends AbstractImporter {
     private static final Provider PROVIDER = new Provider("uk.gov.education", "Department for Education");
-
-    public AbstractDfEImporter(Config config) {
-        super(config);
-    }
 
     public Provider getProvider() {
         return PROVIDER;

--- a/src/main/java/uk/org/tombolo/importer/dfe/SchoolsImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/dfe/SchoolsImporter.java
@@ -8,7 +8,6 @@ import org.apache.poi.ss.usermodel.DataFormatter;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Workbook;
 import uk.org.tombolo.core.*;
-import uk.org.tombolo.importer.Config;
 import uk.org.tombolo.importer.utils.CoordinateUtils;
 import uk.org.tombolo.importer.utils.ExcelUtils;
 import uk.org.tombolo.importer.utils.LatLong;
@@ -63,8 +62,7 @@ public class SchoolsImporter extends AbstractDfEImporter {
         }
     }
 
-    public SchoolsImporter(Config config) {
-        super(config);
+    public SchoolsImporter() {
         datasourceIds = stringsFromEnumeration(DatasourceId.class);
     }
 

--- a/src/main/java/uk/org/tombolo/importer/dft/AbstractDFTImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/dft/AbstractDFTImporter.java
@@ -2,17 +2,12 @@ package uk.org.tombolo.importer.dft;
 
 import uk.org.tombolo.core.Provider;
 import uk.org.tombolo.importer.AbstractOaImporter;
-import uk.org.tombolo.importer.Config;
 
 public abstract class AbstractDFTImporter extends AbstractOaImporter {
     public static final Provider PROVIDER = new Provider(
             "uk.gov.dft",
             "Department for Transport"
     );
-
-    public AbstractDFTImporter(Config config) {
-        super(config);
-    }
 
     @Override
     public Provider getProvider() {

--- a/src/main/java/uk/org/tombolo/importer/dft/AccessibilityImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/dft/AccessibilityImporter.java
@@ -12,7 +12,6 @@ import uk.org.tombolo.core.DatasourceSpec;
 import uk.org.tombolo.core.SubjectType;
 import uk.org.tombolo.core.utils.AttributeUtils;
 import uk.org.tombolo.core.utils.SubjectTypeUtils;
-import uk.org.tombolo.importer.Config;
 import uk.org.tombolo.importer.ons.AbstractONSImporter;
 import uk.org.tombolo.importer.ons.OaImporter;
 import uk.org.tombolo.importer.utils.ExcelUtils;
@@ -89,8 +88,7 @@ public class AccessibilityImporter extends AbstractDFTImporter {
 
     ExcelUtils excelUtils = new ExcelUtils();
 
-    public AccessibilityImporter(Config config){
-        super(config);
+    public AccessibilityImporter(){
         datasourceIds = stringsFromEnumeration(DatasourceId.class);
     }
 

--- a/src/main/java/uk/org/tombolo/importer/dft/TrafficCountImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/dft/TrafficCountImporter.java
@@ -11,10 +11,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.org.tombolo.core.*;
 import uk.org.tombolo.core.utils.AttributeUtils;
-import uk.org.tombolo.core.utils.SubjectTypeUtils;
 import uk.org.tombolo.core.utils.SubjectUtils;
 import uk.org.tombolo.core.utils.TimedValueUtils;
-import uk.org.tombolo.importer.Config;
 import uk.org.tombolo.importer.ConfigurationException;
 import uk.org.tombolo.importer.utils.CoordinateUtils;
 
@@ -251,8 +249,7 @@ public class TrafficCountImporter extends AbstractDFTImporter {
 
 	private static final Logger log = LoggerFactory.getLogger(TrafficCountImporter.class);
 
-	public TrafficCountImporter(Config config) {
-		super(config);
+	public TrafficCountImporter() {
 		datasourceIds = stringsFromEnumeration(DatasourceId.class);
 		geographyLabels = new ArrayList<>(regions);
 		geographyLabels.addAll(localAuthorities);

--- a/src/main/java/uk/org/tombolo/importer/generalcsv/GeneralCSVImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/generalcsv/GeneralCSVImporter.java
@@ -12,8 +12,8 @@ import org.slf4j.LoggerFactory;
 import uk.org.tombolo.core.*;
 import uk.org.tombolo.core.utils.SubjectTypeUtils;
 import uk.org.tombolo.core.utils.SubjectUtils;
-import uk.org.tombolo.importer.AbstractImporter;
 import uk.org.tombolo.importer.Config;
+import uk.org.tombolo.importer.GeneralImporter;
 import uk.org.tombolo.importer.utils.CoordinateUtils;
 
 import java.io.File;
@@ -27,7 +27,7 @@ import java.util.stream.IntStream;
 /**
  * General importer for CSV files.
  */
-public class GeneralCSVImporter extends AbstractImporter {
+public class GeneralCSVImporter extends GeneralImporter {
     static Logger log = LoggerFactory.getLogger(GeneralCSVImporter.class);
 
     private List csvRecords;

--- a/src/main/java/uk/org/tombolo/importer/lac/LAQNImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/lac/LAQNImporter.java
@@ -12,7 +12,6 @@ import uk.org.tombolo.core.utils.SubjectTypeUtils;
 import uk.org.tombolo.core.utils.SubjectUtils;
 import uk.org.tombolo.core.utils.TimedValueUtils;
 import uk.org.tombolo.importer.AbstractImporter;
-import uk.org.tombolo.importer.Config;
 import uk.org.tombolo.importer.Importer;
 import uk.org.tombolo.importer.ParsingException;
 import uk.org.tombolo.importer.utils.JSONReader;
@@ -43,9 +42,7 @@ public class LAQNImporter extends AbstractImporter implements Importer{
     private int attributeSize;
     private ArrayList<LinkedHashMap<String, List<String>>> flatJson;
 
-    public LAQNImporter(Config config) throws Exception {
-        super(config);
-
+    public LAQNImporter() throws Exception {
         datasourceSpec = new DatasourceSpec(getClass(), LAQN_SUBJECT_TYPE_LABEL, LAQN_SUBJECT_TYPE_LABEL,
                 LAQN_SUBJECT_TYPE_DESC, dataSourceURL);
         datasourceIds = Arrays.asList(datasourceSpec.getId());

--- a/src/main/java/uk/org/tombolo/importer/londondatastore/AbstractLondonDatastoreImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/londondatastore/AbstractLondonDatastoreImporter.java
@@ -2,7 +2,6 @@ package uk.org.tombolo.importer.londondatastore;
 
 import uk.org.tombolo.core.Provider;
 import uk.org.tombolo.importer.AbstractOaImporter;
-import uk.org.tombolo.importer.Config;
 
 /**
  * Abstract class for London Datastor importing
@@ -12,10 +11,6 @@ public abstract class AbstractLondonDatastoreImporter extends AbstractOaImporter
             "uk.gov.london",
             "London Datastore - Greater London Authority"
     );
-
-    public AbstractLondonDatastoreImporter(Config config) {
-        super(config);
-    }
 
     @Override
     public Provider getProvider() {

--- a/src/main/java/uk/org/tombolo/importer/londondatastore/AdultObesityImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/londondatastore/AdultObesityImporter.java
@@ -10,10 +10,8 @@ import uk.org.tombolo.core.Datasource;
 import uk.org.tombolo.core.DatasourceSpec;
 import uk.org.tombolo.core.SubjectType;
 import uk.org.tombolo.core.utils.SubjectTypeUtils;
-import uk.org.tombolo.importer.Config;
 import uk.org.tombolo.importer.ons.AbstractONSImporter;
 import uk.org.tombolo.importer.ons.OaImporter;
-import uk.org.tombolo.importer.phe.AbstractPheImporter;
 import uk.org.tombolo.importer.phe.ChildhoodObesityImporter;
 import uk.org.tombolo.importer.utils.ExcelUtils;
 import uk.org.tombolo.importer.utils.extraction.ConstantExtractor;
@@ -53,8 +51,7 @@ public class AdultObesityImporter extends AbstractLondonDatastoreImporter {
 
     private enum AttributeLabel {fractionUnderweight,fractionHealthyWeight,fractionOverweight,fractionObese,fractionExcessWeight}
 
-    public AdultObesityImporter(Config config){
-        super(config);
+    public AdultObesityImporter(){
         datasourceIds = stringsFromEnumeration(DatasourceId.class);
     }
 

--- a/src/main/java/uk/org/tombolo/importer/londondatastore/LondonBoroughProfileImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/londondatastore/LondonBoroughProfileImporter.java
@@ -5,14 +5,12 @@ import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
 import uk.org.tombolo.core.*;
 import uk.org.tombolo.core.utils.SubjectTypeUtils;
-import uk.org.tombolo.importer.Config;
 import uk.org.tombolo.importer.ons.AbstractONSImporter;
 import uk.org.tombolo.importer.ons.OaImporter;
 import uk.org.tombolo.importer.utils.extraction.*;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
-import java.io.InputStreamReader;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -51,8 +49,7 @@ public class LondonBoroughProfileImporter extends AbstractLondonDatastoreImporte
     private static final String DATAFILE
             = "https://files.datapress.com/london/dataset/london-borough-profiles/2017-01-26T18:50:00/london-borough-profiles.csv";
 
-    public LondonBoroughProfileImporter(Config config) {
-        super(config);
+    public LondonBoroughProfileImporter() {
         datasourceIds = stringsFromEnumeration(DatasourceId.class);
     }
 

--- a/src/main/java/uk/org/tombolo/importer/londondatastore/LondonPHOFImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/londondatastore/LondonPHOFImporter.java
@@ -8,7 +8,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.org.tombolo.core.*;
 import uk.org.tombolo.core.utils.SubjectTypeUtils;
-import uk.org.tombolo.importer.Config;
 import uk.org.tombolo.importer.DownloadUtils;
 import uk.org.tombolo.importer.ons.AbstractONSImporter;
 import uk.org.tombolo.importer.ons.OaImporter;
@@ -51,8 +50,7 @@ public class LondonPHOFImporter extends AbstractLondonDatastoreImporter {
 
     Workbook workbook = null;
 
-    public LondonPHOFImporter(Config config){
-        super(config);
+    public LondonPHOFImporter(){
         datasourceIds = stringsFromEnumeration(DatasourceId.class);
     }
 

--- a/src/main/java/uk/org/tombolo/importer/londondatastore/WalkingCyclingBoroughImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/londondatastore/WalkingCyclingBoroughImporter.java
@@ -10,7 +10,6 @@ import uk.org.tombolo.core.Datasource;
 import uk.org.tombolo.core.DatasourceSpec;
 import uk.org.tombolo.core.SubjectType;
 import uk.org.tombolo.core.utils.SubjectTypeUtils;
-import uk.org.tombolo.importer.Config;
 import uk.org.tombolo.importer.DownloadUtils;
 import uk.org.tombolo.importer.ons.AbstractONSImporter;
 import uk.org.tombolo.importer.ons.OaImporter;
@@ -51,8 +50,7 @@ public class WalkingCyclingBoroughImporter extends AbstractLondonDatastoreImport
     private static final String DATAFILE
             = "https://files.datapress.com/london/dataset/walking-and-cycling-borough/walking-cycling-borough.xls";
 
-    public WalkingCyclingBoroughImporter(Config config) {
-        super(config);
+    public WalkingCyclingBoroughImporter() {
         datasourceIds = stringsFromEnumeration(DatasourceId.class);
     }
 

--- a/src/main/java/uk/org/tombolo/importer/nhschoices/HealthOrganisationImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/nhschoices/HealthOrganisationImporter.java
@@ -9,7 +9,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.org.tombolo.core.*;
 import uk.org.tombolo.importer.AbstractImporter;
-import uk.org.tombolo.importer.Config;
 
 import java.net.URL;
 import java.util.Collections;
@@ -34,8 +33,7 @@ public final class HealthOrganisationImporter extends AbstractImporter {
         DatasourceId(DatasourceSpec datasourceSpec) { this.datasourceSpec = datasourceSpec; }
     }
 
-    public HealthOrganisationImporter(Config config) {
-        super(config);
+    public HealthOrganisationImporter() {
         datasourceIds = stringsFromEnumeration(DatasourceId.class);
     }
 

--- a/src/main/java/uk/org/tombolo/importer/ons/AbstractONSImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/ons/AbstractONSImporter.java
@@ -2,7 +2,6 @@ package uk.org.tombolo.importer.ons;
 
 import uk.org.tombolo.core.Provider;
 import uk.org.tombolo.importer.AbstractOaImporter;
-import uk.org.tombolo.importer.Config;
 
 public abstract class AbstractONSImporter extends AbstractOaImporter {
 	public static final String PROP_ONS_API_KEY = "apiKeyOns";
@@ -11,10 +10,6 @@ public abstract class AbstractONSImporter extends AbstractOaImporter {
 			"uk.gov.ons",
 			"Office for National Statistics"
 			);
-
-	public AbstractONSImporter(Config config) {
-		super(config);
-	}
 
 	@Override
 	public Provider getProvider() {

--- a/src/main/java/uk/org/tombolo/importer/ons/CensusImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/ons/CensusImporter.java
@@ -9,7 +9,6 @@ import uk.org.tombolo.core.utils.AttributeUtils;
 import uk.org.tombolo.core.utils.SubjectTypeUtils;
 import uk.org.tombolo.core.utils.SubjectUtils;
 import uk.org.tombolo.core.utils.TimedValueUtils;
-import uk.org.tombolo.importer.Config;
 import uk.org.tombolo.importer.utils.JSONReader;
 import uk.org.tombolo.recipe.SubjectRecipe;
 
@@ -41,10 +40,6 @@ public class CensusImporter extends AbstractONSImporter {
                put("msoa", "TYPE297");
                put("localAuthority", "TYPE463");
     }};
-
-    public CensusImporter(Config config) throws IOException {
-        super(config);
-    }
 
     @Override
     public List<String> getDatasourceIds() {

--- a/src/main/java/uk/org/tombolo/importer/ons/ONSClaimantsImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/ons/ONSClaimantsImporter.java
@@ -5,7 +5,6 @@ import uk.org.tombolo.core.Datasource;
 import uk.org.tombolo.core.DatasourceSpec;
 import uk.org.tombolo.core.SubjectType;
 import uk.org.tombolo.core.utils.SubjectTypeUtils;
-import uk.org.tombolo.importer.Config;
 import uk.org.tombolo.importer.utils.CSVUtils;
 import uk.org.tombolo.importer.utils.extraction.CSVExtractor;
 import uk.org.tombolo.importer.utils.extraction.ConstantExtractor;
@@ -56,8 +55,7 @@ public class ONSClaimantsImporter extends AbstractONSImporter {
 
     private enum AttributeId {claimantCount};
 
-    public ONSClaimantsImporter(Config config){
-        super(config);
+    public ONSClaimantsImporter(){
         datasourceIds = stringsFromEnumeration(DatasourceId.class);
     }
 

--- a/src/main/java/uk/org/tombolo/importer/ons/ONSWagesImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/ons/ONSWagesImporter.java
@@ -10,7 +10,6 @@ import uk.org.tombolo.core.Datasource;
 import uk.org.tombolo.core.DatasourceSpec;
 import uk.org.tombolo.core.SubjectType;
 import uk.org.tombolo.core.utils.SubjectTypeUtils;
-import uk.org.tombolo.importer.Config;
 import uk.org.tombolo.importer.utils.ExcelUtils;
 import uk.org.tombolo.importer.utils.extraction.ConstantExtractor;
 import uk.org.tombolo.importer.utils.extraction.RowCellExtractor;
@@ -130,8 +129,7 @@ public class ONSWagesImporter extends AbstractONSImporter {
             "Female Full-Time", "Female Part-Time"};
     private String[] metricNames = {"Mean", "Median"};
 
-    public ONSWagesImporter(Config config){
-        super(config);
+    public ONSWagesImporter(){
         datasourceIds = stringsFromEnumeration(DatasourceId.class);
     }
 

--- a/src/main/java/uk/org/tombolo/importer/ons/OaImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/ons/OaImporter.java
@@ -9,7 +9,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.org.tombolo.core.*;
 import uk.org.tombolo.importer.AbstractImporter;
-import uk.org.tombolo.importer.Config;
 
 import java.io.InputStream;
 import java.net.URL;
@@ -42,8 +41,7 @@ public final class OaImporter extends AbstractImporter {
         }
     }
 
-    public OaImporter(Config config){
-        super(config);
+    public OaImporter(){
         datasourceIds = stringsFromEnumeration(OaType.class);
     }
 

--- a/src/main/java/uk/org/tombolo/importer/osm/OSMImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/osm/OSMImporter.java
@@ -4,11 +4,13 @@ import de.topobyte.osm4j.pbf.seq.PbfReader;
 import uk.org.tombolo.core.*;
 import uk.org.tombolo.core.utils.AttributeUtils;
 import uk.org.tombolo.importer.AbstractImporter;
-import uk.org.tombolo.importer.Config;
 
 import java.io.File;
 import java.net.URL;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Open street map importer
@@ -61,8 +63,7 @@ public class OSMImporter extends AbstractImporter {
     );
 
 
-    public OSMImporter(Config config) {
-        super(config);
+    public OSMImporter() {
         datasourceIds = new ArrayList<>();
         Arrays.stream(OSMBuiltInImporters.values()).map(builtin -> builtin.name()).forEach(datasourceIds::add);
     }

--- a/src/main/java/uk/org/tombolo/importer/phe/AbstractPheImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/phe/AbstractPheImporter.java
@@ -2,7 +2,6 @@ package uk.org.tombolo.importer.phe;
 
 import uk.org.tombolo.core.Provider;
 import uk.org.tombolo.importer.AbstractOaImporter;
-import uk.org.tombolo.importer.Config;
 
 /**
  * Abstract importer for all date provided by Public Health England.
@@ -12,10 +11,6 @@ public abstract class AbstractPheImporter extends AbstractOaImporter {
             "uk.gov.phe",
             "Public Health England"
     );
-
-    public AbstractPheImporter(Config config) {
-        super(config);
-    }
 
     @Override
     public Provider getProvider() {

--- a/src/main/java/uk/org/tombolo/importer/phe/AdultObesityImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/phe/AdultObesityImporter.java
@@ -10,7 +10,6 @@ import uk.org.tombolo.core.Datasource;
 import uk.org.tombolo.core.DatasourceSpec;
 import uk.org.tombolo.core.SubjectType;
 import uk.org.tombolo.core.utils.SubjectTypeUtils;
-import uk.org.tombolo.importer.Config;
 import uk.org.tombolo.importer.ons.AbstractONSImporter;
 import uk.org.tombolo.importer.ons.OaImporter;
 import uk.org.tombolo.importer.utils.ExcelUtils;
@@ -52,8 +51,7 @@ public class AdultObesityImporter extends AbstractPheImporter {
 
     private enum AttributeLabel {fractionUnderweight,fractionHealthyWeight,fractionOverweight,fractionObese,fractionExcessWeight}
 
-    public AdultObesityImporter(Config config){
-        super(config);
+    public AdultObesityImporter(){
         datasourceIds = stringsFromEnumeration(DatasourceId.class);
     }
 

--- a/src/main/java/uk/org/tombolo/importer/phe/ChildhoodObesityImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/phe/ChildhoodObesityImporter.java
@@ -10,7 +10,6 @@ import uk.org.tombolo.core.Datasource;
 import uk.org.tombolo.core.DatasourceSpec;
 import uk.org.tombolo.core.SubjectType;
 import uk.org.tombolo.core.utils.SubjectTypeUtils;
-import uk.org.tombolo.importer.Config;
 import uk.org.tombolo.importer.ons.AbstractONSImporter;
 import uk.org.tombolo.importer.ons.OaImporter;
 import uk.org.tombolo.importer.utils.ExcelUtils;
@@ -81,8 +80,7 @@ public class ChildhoodObesityImporter extends AbstractPheImporter {
 
     private ExcelUtils excelUtils = new ExcelUtils();;
 
-    public ChildhoodObesityImporter(Config config){
-        super(config);
+    public ChildhoodObesityImporter(){
         datasourceIds = stringsFromEnumeration(DatasourceId.class);
         geographyLabels = stringsFromEnumeration(GeographyLabel.class);
         temporalLabels = stringsFromEnumeration(TemporalLabel.class);

--- a/src/main/java/uk/org/tombolo/importer/spacesyntax/OpenSpaceNetworkImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/spacesyntax/OpenSpaceNetworkImporter.java
@@ -30,10 +30,6 @@ public class OpenSpaceNetworkImporter extends AbstractGeotoolsDataStoreImporter 
 
     private DatasourceSpec datasourceSpec;
 
-    public OpenSpaceNetworkImporter(Config config) {
-        super(config);
-    }
-
     @Override
     public Provider getProvider() {
         return PROVIDER;

--- a/src/main/java/uk/org/tombolo/importer/tfl/TfLImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/tfl/TfLImporter.java
@@ -2,7 +2,6 @@ package uk.org.tombolo.importer.tfl;
 
 import uk.org.tombolo.core.Provider;
 import uk.org.tombolo.importer.AbstractImporter;
-import uk.org.tombolo.importer.Config;
 import uk.org.tombolo.importer.ConfigurationException;
 
 public abstract class TfLImporter extends AbstractImporter {
@@ -14,10 +13,6 @@ public abstract class TfLImporter extends AbstractImporter {
 			"uk.gov.tfl",
 			"Transport for London"
 			);
-
-	public TfLImporter(Config config) {
-		super(config);
-	}
 
 	@Override
 	public Provider getProvider() {

--- a/src/main/java/uk/org/tombolo/importer/tfl/TfLStationsImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/tfl/TfLStationsImporter.java
@@ -11,7 +11,6 @@ import org.w3c.dom.NodeList;
 import uk.org.tombolo.core.*;
 import uk.org.tombolo.core.utils.AttributeUtils;
 import uk.org.tombolo.core.utils.SubjectUtils;
-import uk.org.tombolo.importer.Config;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -50,8 +49,7 @@ public class TfLStationsImporter extends TfLImporter {
 	XPathFactory xPathFactory = XPathFactory.newInstance();
 	XPath xpath = xPathFactory.newXPath();
 
-	public TfLStationsImporter(Config config) throws IOException {
-		super(config);
+	public TfLStationsImporter() throws IOException {
 		datasourceIds = stringsFromEnumeration(DatasourceId.class);
 	}
 

--- a/src/main/java/uk/org/tombolo/importer/twitter/TwitterImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/twitter/TwitterImporter.java
@@ -11,7 +11,6 @@ import twitter4j.TwitterException;
 import twitter4j.TwitterObjectFactory;
 import uk.org.tombolo.core.*;
 import uk.org.tombolo.importer.AbstractImporter;
-import uk.org.tombolo.importer.Config;
 import uk.org.tombolo.importer.ZipUtils;
 
 import javax.json.Json;
@@ -162,8 +161,7 @@ public class TwitterImporter extends AbstractImporter {
         }
     }
 
-    public TwitterImporter(Config config) {
-        super(config);
+    public TwitterImporter() {
         datasourceIds = Arrays.asList(DatasourceId.twitter.name());
     }
 

--- a/src/main/java/uk/org/tombolo/recipe/DatasourceRecipe.java
+++ b/src/main/java/uk/org/tombolo/recipe/DatasourceRecipe.java
@@ -9,21 +9,18 @@ public class DatasourceRecipe {
 	private List<String> geographyScope;
 	private List<String> temporalScope;
 	private List<String> localData;
-	private String configFile = "";
+	private String configFile;
 	
-	public DatasourceRecipe(String importerClass, String datasourceId, List<String> geographyScope, List<String> temporalScope, List<String> localData) {
+	public DatasourceRecipe(String importerClass, String datasourceId, List<String> geographyScope, List<String>
+			temporalScope, List<String> localData, String configFile) {
 		this.importerClass = importerClass;
 		this.datasourceId = datasourceId;
 		this.geographyScope = geographyScope;
 		this.temporalScope = temporalScope;
 		this.localData = localData;
-	}
-
-	public DatasourceRecipe addConfigFile(String configFile) {
 		this.configFile = configFile;
-
-		return this;
 	}
+
 
 	public String getImporterClass() {
 		return importerClass;

--- a/src/test/java/uk/org/tombolo/TestFactory.java
+++ b/src/test/java/uk/org/tombolo/TestFactory.java
@@ -5,7 +5,6 @@ import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.GeometryFactory;
 import uk.org.tombolo.core.*;
 import uk.org.tombolo.core.utils.*;
-import uk.org.tombolo.importer.Config;
 import uk.org.tombolo.importer.ons.OaImporter;
 
 import java.time.LocalDateTime;
@@ -19,8 +18,6 @@ public final class TestFactory {
     public static final Provider DEFAULT_PROVIDER = new Provider("default_provider_label", "default_provider_name");
     public static final String TIMESTAMP = "2011-01-01T00:00:00";
     public static final Geometry FAKE_POINT_GEOMETRY = makePointGeometry(0d, 0d);
-    public static final Config DEFAULT_CONFIG = new Config.Builder(0, "", "", "",
-            new SubjectType(new Provider("", ""), "", "")).build();
 
     /**
      * makeFakeGeometry

--- a/src/test/java/uk/org/tombolo/field/modelling/BasicModellingFieldTest.java
+++ b/src/test/java/uk/org/tombolo/field/modelling/BasicModellingFieldTest.java
@@ -57,7 +57,7 @@ public class BasicModellingFieldTest extends AbstractTest {
                 Collections.singletonList(new DatasourceRecipe(
                         "uk.org.tombolo.importer.ons.OaImporter",
                         "lsoa",
-                        null, null, null)));
+                        null, null, null, null)));
 
         assertEquals(1, field.getDatasources().size());
     }

--- a/src/test/java/uk/org/tombolo/importer/AbstractGeotoolsDataStoreImporterTest.java
+++ b/src/test/java/uk/org/tombolo/importer/AbstractGeotoolsDataStoreImporterTest.java
@@ -22,8 +22,7 @@ public class AbstractGeotoolsDataStoreImporterTest extends AbstractTest {
     // A controlled implementation of the abstract class so we can test it
     class TestGeotoolsDataStoreImporter extends AbstractGeotoolsDataStoreImporter {
 
-        public TestGeotoolsDataStoreImporter(Config config) {
-            super(config);
+        public TestGeotoolsDataStoreImporter() {
             datasourceIds = Arrays.asList("osm_polyline_processed");
         }
 
@@ -84,7 +83,7 @@ public class AbstractGeotoolsDataStoreImporterTest extends AbstractTest {
 
     @Before
     public void setUp() throws Exception {
-        importer = new TestGeotoolsDataStoreImporter(TestFactory.DEFAULT_CONFIG);
+        importer = new TestGeotoolsDataStoreImporter();
         importer.setDownloadUtils(makeTestDownloadUtils());
         testSubjectType = SubjectTypeUtils.getOrCreate(TestFactory.DEFAULT_PROVIDER, "example", "Test Example");
     }

--- a/src/test/java/uk/org/tombolo/importer/AbstractImporterTest.java
+++ b/src/test/java/uk/org/tombolo/importer/AbstractImporterTest.java
@@ -1,7 +1,6 @@
 package uk.org.tombolo.importer;
 
 import org.junit.Test;
-import uk.org.tombolo.TestFactory;
 import uk.org.tombolo.core.Datasource;
 import uk.org.tombolo.core.DatasourceSpec;
 import uk.org.tombolo.core.Provider;
@@ -14,12 +13,9 @@ import static org.junit.Assert.assertTrue;
 
 public class AbstractImporterTest {
 
-    TestAbstractImporter importer = new TestAbstractImporter(TestFactory.DEFAULT_CONFIG);
+    TestAbstractImporter importer = new TestAbstractImporter();
 
     class TestAbstractImporter extends AbstractImporter {
-        public TestAbstractImporter(Config config){
-            super(config);
-        }
 
         @Override
         protected void importDatasource(Datasource datasource, List<String> geographyScope, List<String> temporalScope, List<String> datasourceLocation) throws Exception {

--- a/src/test/java/uk/org/tombolo/importer/dclg/IMDImporterTest.java
+++ b/src/test/java/uk/org/tombolo/importer/dclg/IMDImporterTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertEquals;
  * Local file: 30313bb6-b3eb-3ea4-9cea-95e04b25cc4f.csv
  */
 public class IMDImporterTest extends AbstractTest {
-    IMDImporter imdImporter = new IMDImporter(TestFactory.DEFAULT_CONFIG);
+    IMDImporter imdImporter = new IMDImporter();
 
     Subject subject1;
     Subject subject2;

--- a/src/test/java/uk/org/tombolo/importer/dfe/SchoolsImporterTest.java
+++ b/src/test/java/uk/org/tombolo/importer/dfe/SchoolsImporterTest.java
@@ -3,7 +3,6 @@ package uk.org.tombolo.importer.dfe;
 import org.junit.Before;
 import org.junit.Test;
 import uk.org.tombolo.AbstractTest;
-import uk.org.tombolo.TestFactory;
 import uk.org.tombolo.core.*;
 import uk.org.tombolo.core.utils.AttributeUtils;
 import uk.org.tombolo.core.utils.FixedValueUtils;
@@ -24,7 +23,7 @@ public class SchoolsImporterTest extends AbstractTest {
 
     @Before
     public void before(){
-        importer = new SchoolsImporter(TestFactory.DEFAULT_CONFIG);
+        importer = new SchoolsImporter();
         mockDownloadUtils(importer);
     }
 

--- a/src/test/java/uk/org/tombolo/importer/dft/AccessibilityImporterTest.java
+++ b/src/test/java/uk/org/tombolo/importer/dft/AccessibilityImporterTest.java
@@ -1,7 +1,6 @@
 package uk.org.tombolo.importer.dft;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import uk.org.tombolo.AbstractTest;
 import uk.org.tombolo.TestFactory;
@@ -55,7 +54,7 @@ public class AccessibilityImporterTest extends AbstractTest {
 
     @Before
     public void setUp() throws Exception {
-        importer = new AccessibilityImporter(TestFactory.DEFAULT_CONFIG);
+        importer = new AccessibilityImporter();
         importer.setDownloadUtils(makeTestDownloadUtils());
 
         cityofLondon001A = TestFactory.makeNamedSubject("E01000001");

--- a/src/test/java/uk/org/tombolo/importer/dft/TrafficCountImporterTest.java
+++ b/src/test/java/uk/org/tombolo/importer/dft/TrafficCountImporterTest.java
@@ -6,7 +6,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import uk.org.tombolo.AbstractTest;
-import uk.org.tombolo.TestFactory;
 import uk.org.tombolo.core.Attribute;
 import uk.org.tombolo.core.Provider;
 import uk.org.tombolo.core.Subject;
@@ -43,7 +42,7 @@ public class TrafficCountImporterTest extends AbstractTest {
 
 	@Before
 	public void before(){
-		importer = new TrafficCountImporter(TestFactory.DEFAULT_CONFIG);
+		importer = new TrafficCountImporter();
 		mockDownloadUtils(importer);
 	}
 

--- a/src/test/java/uk/org/tombolo/importer/londondatastore/AdultObesityImporterTest.java
+++ b/src/test/java/uk/org/tombolo/importer/londondatastore/AdultObesityImporterTest.java
@@ -2,7 +2,6 @@ package uk.org.tombolo.importer.londondatastore;
 
 import org.junit.Before;
 import org.junit.Test;
-import uk.org.tombolo.TestFactory;
 import uk.org.tombolo.core.Attribute;
 import uk.org.tombolo.core.DatasourceSpec;
 import uk.org.tombolo.core.TimedValue;
@@ -18,7 +17,7 @@ import static org.junit.Assert.assertEquals;
  */
 public class AdultObesityImporterTest extends AbstractLondonDatastoreTestUtil {
     static final private String DATASOURCE_ID = "adultObesity";
-    private AdultObesityImporter importer = new AdultObesityImporter(TestFactory.DEFAULT_CONFIG);
+    private AdultObesityImporter importer = new AdultObesityImporter();
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/uk/org/tombolo/importer/londondatastore/LondonBoroughProfileImporterTest.java
+++ b/src/test/java/uk/org/tombolo/importer/londondatastore/LondonBoroughProfileImporterTest.java
@@ -19,7 +19,7 @@ import static org.junit.Assert.assertEquals;
  *  Local: 633bdc29-cd58-36bf-bba2-8ff48ea7d46a.csv
  */
 public class LondonBoroughProfileImporterTest extends AbstractLondonDatastoreTestUtil {
-    LondonBoroughProfileImporter importer = new LondonBoroughProfileImporter(TestFactory.DEFAULT_CONFIG);
+    LondonBoroughProfileImporter importer = new LondonBoroughProfileImporter();
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/uk/org/tombolo/importer/londondatastore/LondonPHOFImporterTest.java
+++ b/src/test/java/uk/org/tombolo/importer/londondatastore/LondonPHOFImporterTest.java
@@ -2,7 +2,6 @@ package uk.org.tombolo.importer.londondatastore;
 
 import org.junit.Before;
 import org.junit.Test;
-import uk.org.tombolo.TestFactory;
 import uk.org.tombolo.core.Attribute;
 import uk.org.tombolo.core.Datasource;
 import uk.org.tombolo.core.TimedValue;
@@ -24,7 +23,7 @@ public class LondonPHOFImporterTest extends AbstractLondonDatastoreTestUtil {
 
 	@Before
 	public void before(){
-		importer = new LondonPHOFImporter(TestFactory.DEFAULT_CONFIG);
+		importer = new LondonPHOFImporter();
 		mockDownloadUtils(importer);
 	}
 

--- a/src/test/java/uk/org/tombolo/importer/londondatastore/WalkingCyclingBoroughImporterTest.java
+++ b/src/test/java/uk/org/tombolo/importer/londondatastore/WalkingCyclingBoroughImporterTest.java
@@ -2,7 +2,6 @@ package uk.org.tombolo.importer.londondatastore;
 
 import org.junit.Before;
 import org.junit.Test;
-import uk.org.tombolo.TestFactory;
 import uk.org.tombolo.core.Attribute;
 import uk.org.tombolo.core.Datasource;
 import uk.org.tombolo.core.TimedValue;
@@ -26,7 +25,7 @@ public class WalkingCyclingBoroughImporterTest extends AbstractLondonDatastoreTe
 
 	@Before
 	public void before(){
-		importer = new WalkingCyclingBoroughImporter(TestFactory.DEFAULT_CONFIG);
+		importer = new WalkingCyclingBoroughImporter();
 		mockDownloadUtils(importer);
 	};
 

--- a/src/test/java/uk/org/tombolo/importer/nhschoices/HealthOrganisationImporterTest.java
+++ b/src/test/java/uk/org/tombolo/importer/nhschoices/HealthOrganisationImporterTest.java
@@ -3,8 +3,10 @@ package uk.org.tombolo.importer.nhschoices;
 import org.junit.Before;
 import org.junit.Test;
 import uk.org.tombolo.AbstractTest;
-import uk.org.tombolo.TestFactory;
-import uk.org.tombolo.core.*;
+import uk.org.tombolo.core.DatasourceSpec;
+import uk.org.tombolo.core.Provider;
+import uk.org.tombolo.core.Subject;
+import uk.org.tombolo.core.SubjectType;
 import uk.org.tombolo.core.utils.SubjectTypeUtils;
 import uk.org.tombolo.core.utils.SubjectUtils;
 
@@ -30,7 +32,7 @@ public class HealthOrganisationImporterTest extends AbstractTest {
 
     @Before
     public void setUp() throws Exception {
-        importer = new HealthOrganisationImporter(TestFactory.DEFAULT_CONFIG);
+        importer = new HealthOrganisationImporter();
         mockDownloadUtils(importer);
     }
 

--- a/src/test/java/uk/org/tombolo/importer/ons/CensusImporterTest.java
+++ b/src/test/java/uk/org/tombolo/importer/ons/CensusImporterTest.java
@@ -32,7 +32,7 @@ public class CensusImporterTest extends AbstractTest {
 
     @Before
     public void setup() throws Exception {
-        importer = new CensusImporter(TestFactory.DEFAULT_CONFIG);
+        importer = new CensusImporter();
         mockDownloadUtils(importer);
 
         cityOfLondon01 = TestFactory.makeNamedSubject("E01000001");

--- a/src/test/java/uk/org/tombolo/importer/ons/ONSClaimantsImporterTest.java
+++ b/src/test/java/uk/org/tombolo/importer/ons/ONSClaimantsImporterTest.java
@@ -32,7 +32,7 @@ public class ONSClaimantsImporterTest extends AbstractTest {
 
     @Before
     public void before() throws Exception {
-        importer = new ONSClaimantsImporter(TestFactory.DEFAULT_CONFIG);
+        importer = new ONSClaimantsImporter();
         mockDownloadUtils(importer);
     }
 

--- a/src/test/java/uk/org/tombolo/importer/ons/ONSWagesImporterTest.java
+++ b/src/test/java/uk/org/tombolo/importer/ons/ONSWagesImporterTest.java
@@ -35,7 +35,7 @@ public class ONSWagesImporterTest extends AbstractTest {
 
     @Before
     public void before() throws Exception {
-        importer = new ONSWagesImporter(TestFactory.DEFAULT_CONFIG);
+        importer = new ONSWagesImporter();
         mockDownloadUtils(importer);
         cityOfLondon = TestFactory.makeNamedSubject("E09000001");
         islington = TestFactory.makeNamedSubject("E09000019");

--- a/src/test/java/uk/org/tombolo/importer/ons/OaImporterTest.java
+++ b/src/test/java/uk/org/tombolo/importer/ons/OaImporterTest.java
@@ -3,7 +3,6 @@ package uk.org.tombolo.importer.ons;
 import org.junit.Before;
 import org.junit.Test;
 import uk.org.tombolo.AbstractTest;
-import uk.org.tombolo.TestFactory;
 import uk.org.tombolo.core.Datasource;
 import uk.org.tombolo.core.Subject;
 import uk.org.tombolo.core.SubjectType;
@@ -27,7 +26,7 @@ public class OaImporterTest extends AbstractTest {
 
     @Before
     public void setUp() throws Exception {
-        importer = new OaImporter(TestFactory.DEFAULT_CONFIG);
+        importer = new OaImporter();
         importer.setDownloadUtils(makeTestDownloadUtils());
     }
 

--- a/src/test/java/uk/org/tombolo/importer/osm/OSMImporterTest.java
+++ b/src/test/java/uk/org/tombolo/importer/osm/OSMImporterTest.java
@@ -33,7 +33,7 @@ public class OSMImporterTest extends AbstractTest {
 
     @Before
     public void before(){
-        importer = new OSMImporter(TestFactory.DEFAULT_CONFIG);
+        importer = new OSMImporter();
         mockDownloadUtils(importer);
     }
 

--- a/src/test/java/uk/org/tombolo/importer/phe/AdultObesityImporterTest.java
+++ b/src/test/java/uk/org/tombolo/importer/phe/AdultObesityImporterTest.java
@@ -25,7 +25,7 @@ import static org.junit.Assert.assertEquals;
  */
 public class AdultObesityImporterTest extends AbstractTest {
 	private static final String DATASOURCE_ID = "adultObesity";
-	private AdultObesityImporter importer = new AdultObesityImporter(TestFactory.DEFAULT_CONFIG);
+	private AdultObesityImporter importer = new AdultObesityImporter();
 
 	private Subject cityOfLondon;
 

--- a/src/test/java/uk/org/tombolo/importer/phe/ChildhoodObesityImporterTest.java
+++ b/src/test/java/uk/org/tombolo/importer/phe/ChildhoodObesityImporterTest.java
@@ -35,7 +35,7 @@ public class ChildhoodObesityImporterTest extends AbstractTest {
 
     @Before
     public void setUp() throws Exception {
-        importer = new ChildhoodObesityImporter(TestFactory.DEFAULT_CONFIG);
+        importer = new ChildhoodObesityImporter();
         mockDownloadUtils(importer);
 
         cityOfLondon001 = TestFactory.makeNamedSubject("E02000001");  // City of London 001

--- a/src/test/java/uk/org/tombolo/importer/spacesyntax/OpenSpaceNetworkImporterTest.java
+++ b/src/test/java/uk/org/tombolo/importer/spacesyntax/OpenSpaceNetworkImporterTest.java
@@ -4,7 +4,6 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import uk.org.tombolo.AbstractTest;
-import uk.org.tombolo.TestFactory;
 import uk.org.tombolo.core.*;
 import uk.org.tombolo.core.utils.AttributeUtils;
 import uk.org.tombolo.core.utils.FixedValueUtils;
@@ -26,7 +25,7 @@ public class OpenSpaceNetworkImporterTest extends AbstractTest {
 
     @Before
     public void setUp() throws Exception {
-        importer = new OpenSpaceNetworkImporter(TestFactory.DEFAULT_CONFIG);
+        importer = new OpenSpaceNetworkImporter();
         importer.setDownloadUtils(makeTestDownloadUtils());
         Properties props = new Properties();
         props.put("openSpaceNetworkUsername", "");

--- a/src/test/java/uk/org/tombolo/importer/tfl/TfLStationsImporterTest.java
+++ b/src/test/java/uk/org/tombolo/importer/tfl/TfLStationsImporterTest.java
@@ -5,7 +5,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import uk.org.tombolo.AbstractTest;
-import uk.org.tombolo.TestFactory;
 import uk.org.tombolo.importer.ConfigurationException;
 
 import java.util.Properties;
@@ -25,7 +24,7 @@ public class TfLStationsImporterTest extends AbstractTest {
 
 	@Before
 	public void before() throws Exception {
-		importer = new TfLStationsImporter(TestFactory.DEFAULT_CONFIG);
+		importer = new TfLStationsImporter();
 		mockDownloadUtils(importer);
 		importer.configure(makeApiKeyProperties());
 	}
@@ -44,7 +43,7 @@ public class TfLStationsImporterTest extends AbstractTest {
 
 	@Test
 	public void testNonConfigured() throws Exception {
-		importer = new TfLStationsImporter(TestFactory.DEFAULT_CONFIG);
+		importer = new TfLStationsImporter();
 		mockDownloadUtils(importer);
 
 		thrown.expect(ConfigurationException.class);
@@ -57,7 +56,7 @@ public class TfLStationsImporterTest extends AbstractTest {
 		Properties properties = new Properties();
 		properties.put(TfLImporter.PROP_API_APP_ID, "dummy id");
 
-		importer = new TfLStationsImporter(TestFactory.DEFAULT_CONFIG);
+		importer = new TfLStationsImporter();
 		mockDownloadUtils(importer);
 
 		thrown.expect(ConfigurationException.class);

--- a/src/test/java/uk/org/tombolo/importer/twitter/TwitterImporterTest.java
+++ b/src/test/java/uk/org/tombolo/importer/twitter/TwitterImporterTest.java
@@ -4,7 +4,6 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import uk.org.tombolo.AbstractTest;
-import uk.org.tombolo.TestFactory;
 import uk.org.tombolo.core.Attribute;
 import uk.org.tombolo.core.FixedValue;
 import uk.org.tombolo.core.Subject;
@@ -35,7 +34,7 @@ public class TwitterImporterTest extends AbstractTest {
 
     @Before
     public void before(){
-        importer = new TwitterImporter(TestFactory.DEFAULT_CONFIG);
+        importer = new TwitterImporter();
         mockDownloadUtils(importer);
     }
 

--- a/src/test/java/uk/org/tombolo/lac/LAQNImporterTest.java
+++ b/src/test/java/uk/org/tombolo/lac/LAQNImporterTest.java
@@ -6,7 +6,6 @@ import org.junit.Test;
 import uk.org.tombolo.AbstractTest;
 import uk.org.tombolo.core.*;
 import uk.org.tombolo.core.utils.*;
-import uk.org.tombolo.importer.Config;
 import uk.org.tombolo.importer.lac.LAQNImporter;
 
 import java.lang.reflect.Constructor;
@@ -24,18 +23,12 @@ import static org.junit.Assert.assertEquals;
 public class LAQNImporterTest extends AbstractTest {
 
     private LAQNImporter laqnImporter;
-    private Config defaultConfig = new Config.Builder(0, "",
-                            "", "erg.kcl.ac.uk",
-                            new SubjectType(new Provider("erg.kcl.ac.uk",
-                                    "Environmental Research Group Kings College London"),
-                                    "airQualityControl", "Quantity of gases in air by Kings College London"))
-            .build();
 
 
     @Before
     public void setUp() throws Exception {
 
-        laqnImporter = new LAQNImporter(defaultConfig);
+        laqnImporter = new LAQNImporter();
         mockDownloadUtils(laqnImporter);
 
     }
@@ -45,8 +38,8 @@ public class LAQNImporterTest extends AbstractTest {
                                                String... args) throws ClassNotFoundException, IllegalAccessException, InstantiationException, NoSuchMethodException, InvocationTargetException {
 
         Class<?> theClass = Class.forName("uk.org.tombolo.importer.lac.LAQNImporter");
-        Constructor<?> constructor = theClass.getConstructor(Config.class);
-        Object object = constructor.newInstance(defaultConfig);
+        Constructor<?> constructor = theClass.getConstructor();
+        Object object = constructor.newInstance();
 
         Method method;
         if (args.length > 0) {


### PR DESCRIPTION
Fixes #420

### Description
*Context:* When creating the general csv importer, there was a need for a configuration file where to specify how to interpret the dataset and other info so it could be used in the DC data structure (see [example](https://github.com/FutureCitiesCatapult/TomboloDigitalConnector/blob/master/src/test/resources/datacache/TomboloData/general.csv.provider/config.properties)). At the time, we decided that it made sense to have a configuration file for each importer not only the general ones. This way we could leave to the user the decision of personalising the built-in importer via the config file. This meant of course changes in the present importers we did not implement. What seemed to be a good design decision at the time (might still be) was not adopted in practice.

In this PR I left the config file only for the general importers and removed it from the rest. I created an Abstract class to represent the importers that have config files so it should be ok if we want it for future importers.

### Checklist

- []~~Created new test(s) (if applicable)~~
- [ ]~~Updated the README / documentation (if applicable)~~
