### PR TITLE
Import `OaImporter` subjects inside the interested importer

### DIFF
--- a/src/main/java/uk/org/tombolo/execution/DataExportEngine.java
+++ b/src/main/java/uk/org/tombolo/execution/DataExportEngine.java
@@ -92,12 +92,12 @@ public class DataExportEngine implements ExecutionEngine {
 		Importer importer = initialiseImporter(datasourceRecipe.getImporterClass(), datasourceRecipe.getConfigFile());
 		importer.configure(apiKeys);
 		importer.setDownloadUtils(downloadUtils);
+		importer.setSubjectRecipes(subjectRecipes);
 		importer.importDatasource(
 				datasourceRecipe.getDatasourceId(),
 				datasourceRecipe.getGeographyScope(),
 				datasourceRecipe.getTemporalScope(),
 				datasourceRecipe.getLocalData(),
-				subjectRecipes,
 				forceImports.doesMatch(datasourceRecipe.getImporterClass())
 		);
 	}

--- a/src/main/java/uk/org/tombolo/execution/DataExportEngine.java
+++ b/src/main/java/uk/org/tombolo/execution/DataExportEngine.java
@@ -42,10 +42,11 @@ public class DataExportEngine implements ExecutionEngine {
 	}
 
 	public void execute(DataExportRecipe dataExportRecipe, Writer writer, ImporterMatcher forceImports) throws Exception {
+		List<SubjectRecipe> subjectRecipes = dataExportRecipe.getDataset().getSubjects();
 		// Import datasources that are in the global dataset specification
 		for (DatasourceRecipe datasourceSpec : dataExportRecipe.getDataset().getDatasources()) {
 			if (!datasourceSpec.getImporterClass().isEmpty()) {
-				importDatasource(forceImports, datasourceSpec, dataExportRecipe.getDataset().getSubjects());
+				importDatasource(forceImports, datasourceSpec, subjectRecipes);
 			}
 		}
 
@@ -62,7 +63,7 @@ public class DataExportEngine implements ExecutionEngine {
 
 		// Use the new fields method
 		log.info("Exporting ...");
-		List<SubjectRecipe> subjectSpecList = dataExportRecipe.getDataset().getSubjects();
+		List<SubjectRecipe> subjectSpecList = subjectRecipes;
 		Exporter exporter = (Exporter) Class.forName(dataExportRecipe.getExporter()).newInstance();
 		List<Subject> subjects = SubjectUtils.getSubjectBySpecifications(subjectSpecList);
 		exporter.write(writer, subjects, fields, dataExportRecipe.getTimeStamp());
@@ -102,7 +103,7 @@ public class DataExportEngine implements ExecutionEngine {
 	}
 
 	private Importer initialiseImporter(String importerClass, String configFile) throws Exception {
-		if (configFile != null) {
+		if (configFile != null && !"".equals(configFile)) {
 			Config importerConfiguration = ConfigUtils.loadConfig(
 					AbstractRunner.loadProperties("Configuration file", configFile));
 			return (Importer) Class.forName(importerClass).getDeclaredConstructor(Config.class).newInstance(importerConfiguration);

--- a/src/main/java/uk/org/tombolo/importer/AbstractImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/AbstractImporter.java
@@ -64,6 +64,9 @@ public abstract class AbstractImporter implements Importer {
 		this.downloadUtils = downloadUtils;
 	}
 
+	@Override
+	public void setSubjectRecipes(List<SubjectRecipe> subjectRecipes) { this.subjectRecipes  = subjectRecipes; }
+
 	/**
 	 * Loads the data-source identified by datasourceId into the underlying data store
 	 *
@@ -74,12 +77,12 @@ public abstract class AbstractImporter implements Importer {
 	 */
 	@Override
 	public void importDatasource(@Nonnull String datasourceId, List<String> geographyScope, List<String> temporalScope, List<String> datasourceLocation) throws Exception {
-		importDatasource(datasourceId, geographyScope, temporalScope, datasourceLocation, Collections.emptyList(), false);
+		importDatasource(datasourceId, geographyScope, temporalScope, datasourceLocation, false);
 	}
 
 	/**
-	 * Loads the data-source identified by datasourceId into the underlying data store 
-	 * 
+	 * Loads the data-source identified by datasourceId into the underlying data store
+	 *
 	 * @param datasourceId
 	 * @param geographyScope
 	 * @param temporalScope
@@ -87,7 +90,7 @@ public abstract class AbstractImporter implements Importer {
 	 * @throws Exception
 	 */
 	@Override
-	public void importDatasource(@Nonnull String datasourceId, List<String> geographyScope, List<String> temporalScope, List<String> datasourceLocation, @Nonnull List<SubjectRecipe> subjectRecipes, Boolean force) throws Exception {
+	public void importDatasource(@Nonnull String datasourceId, List<String> geographyScope, List<String> temporalScope, List<String> datasourceLocation, Boolean force) throws Exception {
 		if (!datasourceExists(datasourceId))
 			throw new ConfigurationException("Unknown DatasourceId:" + datasourceId);
 
@@ -98,8 +101,6 @@ public abstract class AbstractImporter implements Importer {
 		} else {
 			log.info("Importing {}:{}",
 					this.getClass().getCanonicalName(), datasourceId);
-			// Setting Subject Recipe object
-			this.subjectRecipes = subjectRecipes;
 			// Get the details for the data source
 			Datasource datasource = getDatasource(datasourceId);
 			saveDatasourceMetadata(datasource);

--- a/src/main/java/uk/org/tombolo/importer/AbstractImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/AbstractImporter.java
@@ -37,6 +37,7 @@ public abstract class AbstractImporter implements Importer {
 		datasourceIds = Collections.emptyList();
 		geographyLabels = Collections.singletonList(DEFAULT_GEOGRAPHY);
 		temporalLabels = Collections.singletonList(DEFAULT_TEMPORAL);
+		subjectRecipes = Collections.emptyList();
 	}
 
 	@Override

--- a/src/main/java/uk/org/tombolo/importer/AbstractOaImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/AbstractOaImporter.java
@@ -1,7 +1,6 @@
 package uk.org.tombolo.importer;
 
 import uk.org.tombolo.importer.ons.OaImporter;
-import uk.org.tombolo.recipe.SubjectRecipe;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;
@@ -15,7 +14,7 @@ public abstract class AbstractOaImporter extends AbstractImporter {
 
     @Override
     public void importDatasource(@Nonnull String datasourceId, List<String> geographyScope, List<String> temporalScope,
-                                 List<String> datasourceLocation, @Nonnull List<SubjectRecipe> subjectRecipes, Boolean force)
+                                 List<String> datasourceLocation, Boolean force)
                                 throws Exception {
         List<String> oaDatasourceIds = getOaDatasourceIds();
         if (!oaDatasourceIds.isEmpty()) {
@@ -24,10 +23,10 @@ public abstract class AbstractOaImporter extends AbstractImporter {
             // Import the subjects defined by OaImporter first
             for (String id : oaDatasourceIds) {
                 oaImporter.importDatasource(id, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-                        subjectRecipes, false);
+                        false);
             }
         }
-        super.importDatasource(datasourceId, geographyScope, temporalScope, datasourceLocation, subjectRecipes, force);
+        super.importDatasource(datasourceId, geographyScope, temporalScope, datasourceLocation, force);
     }
 
     /**

--- a/src/main/java/uk/org/tombolo/importer/AbstractOaImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/AbstractOaImporter.java
@@ -17,14 +17,16 @@ public abstract class AbstractOaImporter extends AbstractImporter {
     public void importDatasource(@Nonnull String datasourceId, List<String> geographyScope, List<String> temporalScope,
                                  List<String> datasourceLocation, @Nonnull List<SubjectRecipe> subjectRecipes, Boolean force)
                                 throws Exception {
-        OaImporter oaImporter = new OaImporter();
-        oaImporter.setDownloadUtils(downloadUtils);
-        // Import the subjects defined by OaImporter first
-        for (String id : getOaDatasourceIds()) {
-            oaImporter.importDatasource(id, Collections.EMPTY_LIST, Collections.EMPTY_LIST, Collections.EMPTY_LIST,
-                    subjectRecipes, false);
+        List<String> oaDatasourceIds = getOaDatasourceIds();
+        if (!oaDatasourceIds.isEmpty()) {
+            OaImporter oaImporter = new OaImporter();
+            oaImporter.setDownloadUtils(downloadUtils);
+            // Import the subjects defined by OaImporter first
+            for (String id : oaDatasourceIds) {
+                oaImporter.importDatasource(id, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
+                        subjectRecipes, false);
+            }
         }
-
         super.importDatasource(datasourceId, geographyScope, temporalScope, datasourceLocation, subjectRecipes, force);
     }
 

--- a/src/main/java/uk/org/tombolo/importer/AbstractOaImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/AbstractOaImporter.java
@@ -1,14 +1,16 @@
 package uk.org.tombolo.importer;
 
-import uk.org.tombolo.core.utils.DatabaseJournal;
 import uk.org.tombolo.importer.ons.OaImporter;
-import uk.org.tombolo.importer.utils.JournalEntryUtils;
 import uk.org.tombolo.recipe.SubjectRecipe;
 
 import javax.annotation.Nonnull;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * AbstractOaImporter is extended by importers that do not define a new subject type but use existing ones,
+ * making them dependent on the importers that define the subject types originally.
+ */
 public abstract class AbstractOaImporter extends AbstractImporter {
 
     @Override
@@ -17,14 +19,18 @@ public abstract class AbstractOaImporter extends AbstractImporter {
                                 throws Exception {
         OaImporter oaImporter = new OaImporter();
         oaImporter.setDownloadUtils(downloadUtils);
-        for (SubjectRecipe subjectRecipe : subjectRecipes) {
-            if (!DatabaseJournal.journalHasEntry(JournalEntryUtils.getJournalEntryForDatasourceId(
-                "uk.org.tombolo.importer.ons.OaImporter", subjectRecipe.getSubjectType(), geographyScope,
-                    temporalScope, datasourceLocation))) {
-                oaImporter.importDatasource(subjectRecipe.getSubjectType(), Collections.EMPTY_LIST, Collections.EMPTY_LIST,
-                        Collections.EMPTY_LIST, subjectRecipes, false);
-            }
+        // Import the subjects defined by OaImporter first
+        for (String id : getOaDatasourceIds()) {
+            oaImporter.importDatasource(id, Collections.EMPTY_LIST, Collections.EMPTY_LIST, Collections.EMPTY_LIST,
+                    subjectRecipes, false);
         }
+
         super.importDatasource(datasourceId, geographyScope, temporalScope, datasourceLocation, subjectRecipes, force);
     }
+
+    /**
+     * @return List of the datasourceIds needed to import the subjects defined in OaImporter so its subject types can
+     * be used by the current importer.
+     */
+    protected abstract List<String> getOaDatasourceIds();
 }

--- a/src/main/java/uk/org/tombolo/importer/Importer.java
+++ b/src/main/java/uk/org/tombolo/importer/Importer.java
@@ -18,7 +18,7 @@ public interface Importer {
 	 * @return
 	 * @throws Exception
 	 */
-	public List<String> getDatasourceIds();
+	List<String> getDatasourceIds();
 
 	/**
 	 * Returns true if a datasource with said id exists
@@ -33,7 +33,7 @@ public interface Importer {
 	 *
 	 * @return
 	 */
-	public List<String> getGeographyLabels();
+	List<String> getGeographyLabels();
 
 	/**
 	 * Returna all labels that can be used to restrict the temporal scope of the import.
@@ -56,8 +56,8 @@ public interface Importer {
 	 * @param datasourceLocation A list of file locations in case the data comes from a local source
 	 * @throws Exception
 	 */
-	public void importDatasource(@Nonnull  String datasourceId, @Nullable List<String> geographyScope, @Nullable List<String> temporalScope, @Nullable List<String> datasourceLocation) throws Exception;
-	public void importDatasource(@Nonnull String datasourceId, @Nullable List<String> geographyScope, @Nullable List<String> temporalScope, @Nullable List<String> datasourceLocation, @Nonnull List<SubjectRecipe> subjectRecipes, Boolean force) throws Exception;
+	void importDatasource(@Nonnull  String datasourceId, @Nullable List<String> geographyScope, @Nullable List<String> temporalScope, @Nullable List<String> datasourceLocation) throws Exception;
+	void importDatasource(@Nonnull String datasourceId, @Nullable List<String> geographyScope, @Nullable List<String> temporalScope, @Nullable List<String> datasourceLocation, Boolean force) throws Exception;
 
 	/**
 	 * Function that takes in a buffer of subjects and saves it to the database and clears the buffer.
@@ -84,6 +84,11 @@ public interface Importer {
 	void saveAndClearFixedValueBuffer(List<FixedValue> fixedValues);
 
 	void setDownloadUtils(DownloadUtils downloadUtils);
+
+	/*
+	 * Sets the subjects specified in the recipe to be used by the importer to make import decisions.
+	 */
+	void setSubjectRecipes(List<SubjectRecipe> subjectRecipes);
 
 	void configure(Properties properties) throws ConfigurationException;
 	void verifyConfiguration() throws ConfigurationException;

--- a/src/main/java/uk/org/tombolo/importer/dclg/AbstractDCLGImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/dclg/AbstractDCLGImporter.java
@@ -2,6 +2,10 @@ package uk.org.tombolo.importer.dclg;
 
 import uk.org.tombolo.core.Provider;
 import uk.org.tombolo.importer.AbstractOaImporter;
+import uk.org.tombolo.importer.ons.OaImporter;
+
+import java.util.Collections;
+import java.util.List;
 
 public abstract class AbstractDCLGImporter extends AbstractOaImporter {
     public static final Provider PROVIDER
@@ -10,6 +14,11 @@ public abstract class AbstractDCLGImporter extends AbstractOaImporter {
     @Override
     public Provider getProvider() {
         return PROVIDER;
+    }
+
+    @Override
+    protected List<String> getOaDatasourceIds() {
+        return Collections.singletonList(OaImporter.OaType.lsoa.datasourceSpec.getId());
     }
 
 }

--- a/src/main/java/uk/org/tombolo/importer/dclg/IMDImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/dclg/IMDImporter.java
@@ -64,6 +64,12 @@ public class IMDImporter extends AbstractDCLGImporter {
 
     @Override
     protected void importDatasource(Datasource datasource, List<String> geographyScope, List<String> temporalScope, List<String> datasourceLocation) throws Exception {
+//        // Persist the lsoa subjects from OaImporter as we do not define a new subject type here but get an existing
+//        // one
+//        OaImporter oaImporter = new OaImporter();
+//        oaImporter.setDownloadUtils(downloadUtils);
+//        oaImporter.importDatasource(OaImporter.OaType.lsoa.datasourceSpec.getId(), null, null, null);
+
         // Save timed values
         LocalDateTime timestamp = LocalDateTime.parse("2015-01-01T00:00:01", TimedValueId.DATE_TIME_FORMATTER);
         String line;

--- a/src/main/java/uk/org/tombolo/importer/dclg/IMDImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/dclg/IMDImporter.java
@@ -64,12 +64,6 @@ public class IMDImporter extends AbstractDCLGImporter {
 
     @Override
     protected void importDatasource(Datasource datasource, List<String> geographyScope, List<String> temporalScope, List<String> datasourceLocation) throws Exception {
-//        // Persist the lsoa subjects from OaImporter as we do not define a new subject type here but get an existing
-//        // one
-//        OaImporter oaImporter = new OaImporter();
-//        oaImporter.setDownloadUtils(downloadUtils);
-//        oaImporter.importDatasource(OaImporter.OaType.lsoa.datasourceSpec.getId(), null, null, null);
-
         // Save timed values
         LocalDateTime timestamp = LocalDateTime.parse("2015-01-01T00:00:01", TimedValueId.DATE_TIME_FORMATTER);
         String line;

--- a/src/main/java/uk/org/tombolo/importer/dft/AccessibilityImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/dft/AccessibilityImporter.java
@@ -21,6 +21,7 @@ import uk.org.tombolo.importer.utils.extraction.TimedValueExtractor;
 
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -105,6 +106,10 @@ public class AccessibilityImporter extends AbstractDFTImporter {
         return super.getDatasource(datasourceId);
     }
 
+    @Override
+    protected List<String> getOaDatasourceIds() {
+        return Collections.singletonList(OaImporter.OaType.lsoa.datasourceSpec.getId());
+    }
 
     @Override
     public List<Attribute> getTimedValueAttributes(String datasourceId) throws Exception {

--- a/src/main/java/uk/org/tombolo/importer/dft/TrafficCountImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/dft/TrafficCountImporter.java
@@ -13,6 +13,7 @@ import uk.org.tombolo.core.*;
 import uk.org.tombolo.core.utils.AttributeUtils;
 import uk.org.tombolo.core.utils.SubjectUtils;
 import uk.org.tombolo.core.utils.TimedValueUtils;
+import uk.org.tombolo.importer.AbstractImporter;
 import uk.org.tombolo.importer.ConfigurationException;
 import uk.org.tombolo.importer.utils.CoordinateUtils;
 
@@ -36,7 +37,7 @@ import java.util.*;
  * - http://api.dft.gov.uk/v3/trafficcounts/export/la/Aberdeen+City.csv
  *
  */
-public class TrafficCountImporter extends AbstractDFTImporter {
+public class TrafficCountImporter extends AbstractImporter {
 	private static final String REGION = "region/";
 	private static final String LA = "la/";
 	private static final String CSV_POSTFIX = ".csv";
@@ -255,6 +256,11 @@ public class TrafficCountImporter extends AbstractDFTImporter {
 		geographyLabels.addAll(localAuthorities);
 	}
 
+	@Override
+	public Provider getProvider() {
+		return AbstractDFTImporter.PROVIDER;
+	}
+	
 	@Override
 	public int getTimedValueBufferSize() {
 		return TIMED_VALUE_BUFFER_SIZE;

--- a/src/main/java/uk/org/tombolo/importer/lac/LAQNImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/lac/LAQNImporter.java
@@ -12,7 +12,6 @@ import uk.org.tombolo.core.utils.SubjectTypeUtils;
 import uk.org.tombolo.core.utils.SubjectUtils;
 import uk.org.tombolo.core.utils.TimedValueUtils;
 import uk.org.tombolo.importer.AbstractImporter;
-import uk.org.tombolo.importer.Importer;
 import uk.org.tombolo.importer.ParsingException;
 import uk.org.tombolo.importer.utils.JSONReader;
 
@@ -26,7 +25,7 @@ import java.util.stream.IntStream;
 /**
  * London Air Quality Importer
  */
-public class LAQNImporter extends AbstractImporter implements Importer{
+public class LAQNImporter extends AbstractImporter {
     private static final Logger log = LoggerFactory.getLogger(LAQNImporter.class);
 
     private static final String LAQN_PROVIDER_LABEL = "erg.kcl.ac.uk";

--- a/src/main/java/uk/org/tombolo/importer/londondatastore/AbstractLondonDatastoreImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/londondatastore/AbstractLondonDatastoreImporter.java
@@ -2,6 +2,10 @@ package uk.org.tombolo.importer.londondatastore;
 
 import uk.org.tombolo.core.Provider;
 import uk.org.tombolo.importer.AbstractOaImporter;
+import uk.org.tombolo.importer.ons.OaImporter;
+
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Abstract class for London Datastor importing
@@ -15,6 +19,11 @@ public abstract class AbstractLondonDatastoreImporter extends AbstractOaImporter
     @Override
     public Provider getProvider() {
         return PROVIDER;
+    }
+
+    @Override
+    protected List<String> getOaDatasourceIds() {
+        return Collections.singletonList(OaImporter.OaType.localAuthority.datasourceSpec.getId());
     }
 
 }

--- a/src/main/java/uk/org/tombolo/importer/ons/AbstractONSImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/ons/AbstractONSImporter.java
@@ -4,8 +4,7 @@ import uk.org.tombolo.core.Provider;
 import uk.org.tombolo.importer.AbstractOaImporter;
 
 public abstract class AbstractONSImporter extends AbstractOaImporter {
-	public static final String PROP_ONS_API_KEY = "apiKeyOns";
-	
+
 	public static final Provider PROVIDER = new Provider(
 			"uk.gov.ons",
 			"Office for National Statistics"

--- a/src/main/java/uk/org/tombolo/importer/ons/CensusImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/ons/CensusImporter.java
@@ -2,6 +2,7 @@ package uk.org.tombolo.importer.ons;
 
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
+import org.apache.commons.lang3.EnumUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.org.tombolo.core.*;
@@ -43,12 +44,32 @@ public class CensusImporter extends AbstractONSImporter {
 
     @Override
     public List<String> getDatasourceIds() {
-        return getDataSourceIDs();
+        try {
+            return getSeedData().stream().map(CensusDescription::getDataSetTable)
+                    .collect(Collectors.toCollection(ArrayList::new));
+        } catch (IOException e) {
+            log.error("An error has occurred while downloading DatasourceID's" + e.getMessage());
+        }
+
+        return Collections.emptyList();
+    }
+
+    @Override
+    protected List<String> getOaDatasourceIds() {
+        return subjectRecipes.stream().filter(subjectRecipe ->
+            EnumUtils.isValidEnum(OaImporter.OaType.class, subjectRecipe.getSubjectType())).map(subjectRecipe ->
+                subjectRecipe.getSubjectType()).collect(Collectors.toCollection(ArrayList::new));
     }
 
     @Override
     public DatasourceSpec getDatasourceSpec(String datasourceIdString) throws Exception {
-        return getDataSourceSpecObject(datasourceIdString);
+        for (CensusDescription description : descriptions) {
+            if (description.getDataSetTable().equalsIgnoreCase(datasourceIdString)) {
+                return new DatasourceSpec(getClass(), datasourceIdString, description.getDataSetDescription(), description.getDataSetDescription(),
+                        "https://www.nomisweb.co.uk/census/2011/" + datasourceIdString);
+            }
+        }
+        throw new Error("Unknown data-source-id: " + datasourceIdString);
     }
 
     @Override
@@ -153,27 +174,6 @@ public class CensusImporter extends AbstractONSImporter {
         });
 
         return descriptions;
-    }
-
-    private List<String> getDataSourceIDs() {
-        try {
-            return getSeedData().stream().map(CensusDescription::getDataSetTable)
-                    .collect(Collectors.toCollection(ArrayList::new));
-        } catch (IOException e) {
-            log.error("An error has occurred while downloading DatasourceID's" + e.getMessage());
-        }
-
-        return Collections.emptyList();
-    }
-
-    private DatasourceSpec getDataSourceSpecObject(String dataSourceId) {
-        for (CensusDescription description : descriptions) {
-            if (description.getDataSetTable().equalsIgnoreCase(dataSourceId)) {
-                return new DatasourceSpec(getClass(), dataSourceId, description.getDataSetDescription(), description.getDataSetDescription(),
-                        "https://www.nomisweb.co.uk/census/2011/" + dataSourceId);
-            }
-        }
-        throw new Error("Unknown data-source-id: " + dataSourceId);
     }
 
     private String getRecordId(String dataSourceId) {

--- a/src/main/java/uk/org/tombolo/importer/ons/ONSClaimantsImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/ons/ONSClaimantsImporter.java
@@ -65,6 +65,11 @@ public class ONSClaimantsImporter extends AbstractONSImporter {
     }
 
     @Override
+    protected List<String> getOaDatasourceIds() {
+        return Collections.singletonList(OaImporter.OaType.lsoa.datasourceSpec.getId());
+    }
+
+    @Override
     protected void importDatasource(Datasource datasource, List<String> geographyScope, List<String> temporalScope, List<String> datasourceLocation) throws Exception {
         SubjectType subjectType = SubjectTypeUtils.getOrCreate(AbstractONSImporter.PROVIDER,
                 OaImporter.OaType.lsoa.name(), OaImporter.OaType.lsoa.datasourceSpec.getDescription());

--- a/src/main/java/uk/org/tombolo/importer/ons/ONSWagesImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/ons/ONSWagesImporter.java
@@ -18,6 +18,7 @@ import uk.org.tombolo.importer.utils.extraction.TimedValueExtractor;
 import java.io.File;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -136,6 +137,11 @@ public class ONSWagesImporter extends AbstractONSImporter {
     @Override
     public DatasourceSpec getDatasourceSpec(String datasourceIdString) throws Exception {
         return DatasourceId.valueOf(datasourceIdString).datasourceSpec;
+    }
+
+    @Override
+    protected List<String> getOaDatasourceIds() {
+        return Collections.singletonList(OaImporter.OaType.localAuthority.datasourceSpec.getId());
     }
 
     @Override

--- a/src/main/java/uk/org/tombolo/importer/ons/OaImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/ons/OaImporter.java
@@ -19,11 +19,6 @@ import java.util.List;
 public final class OaImporter extends AbstractImporter {
     private static Logger log = LoggerFactory.getLogger(OaImporter.class);
 
-    public static final Provider PROVIDER = new Provider(
-            "uk.gov.ons",
-            "Office for National Statistics"
-    );
-
     public enum OaType {
         lsoa(new DatasourceSpec(OaImporter.class,"lsoa","LSOA","Lower Layer Super Output Areas",null),
                 "https://raw.githubusercontent.com/FutureCitiesCatapult/TomboloOpenData/master/UK_2011_Census_Boundaries__LSOA.geojson"),
@@ -52,7 +47,7 @@ public final class OaImporter extends AbstractImporter {
 
     @Override
     public Provider getProvider() {
-        return PROVIDER;
+        return AbstractONSImporter.PROVIDER;
     }
 
     @Override

--- a/src/main/java/uk/org/tombolo/importer/phe/AbstractPheImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/phe/AbstractPheImporter.java
@@ -2,6 +2,10 @@ package uk.org.tombolo.importer.phe;
 
 import uk.org.tombolo.core.Provider;
 import uk.org.tombolo.importer.AbstractOaImporter;
+import uk.org.tombolo.importer.ons.OaImporter;
+
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Abstract importer for all date provided by Public Health England.
@@ -17,5 +21,8 @@ public abstract class AbstractPheImporter extends AbstractOaImporter {
         return PROVIDER;
     }
 
-
+    @Override
+    protected List<String> getOaDatasourceIds() {
+        return Collections.singletonList(OaImporter.OaType.localAuthority.datasourceSpec.getId());
+    }
 }

--- a/src/main/java/uk/org/tombolo/importer/phe/AbstractPheImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/phe/AbstractPheImporter.java
@@ -6,7 +6,6 @@ import uk.org.tombolo.importer.ons.OaImporter;
 
 import java.util.Collections;
 import java.util.List;
-
 /**
  * Abstract importer for all date provided by Public Health England.
  */

--- a/src/main/java/uk/org/tombolo/importer/phe/ChildhoodObesityImporter.java
+++ b/src/main/java/uk/org/tombolo/importer/phe/ChildhoodObesityImporter.java
@@ -92,6 +92,11 @@ public class ChildhoodObesityImporter extends AbstractPheImporter {
     }
 
     @Override
+    protected List<String> getOaDatasourceIds() {
+        return Arrays.asList(super.getOaDatasourceIds().get(0), OaImporter.OaType.msoa.datasourceSpec.getId());
+    }
+
+    @Override
     protected void importDatasource(Datasource datasource, List<String> geographyScope, List<String> temporalScope,  List<String> datasourceLocation) throws Exception {
         // Choose the apppropriate workbook sheet
         Workbook workbook = excelUtils.getWorkbook(

--- a/src/test/java/uk/org/tombolo/importer/AbstractOaImporterTest.java
+++ b/src/test/java/uk/org/tombolo/importer/AbstractOaImporterTest.java
@@ -1,0 +1,67 @@
+package uk.org.tombolo.importer;
+
+import org.junit.Before;
+import org.junit.Test;
+import uk.org.tombolo.AbstractTest;
+import uk.org.tombolo.TestFactory;
+import uk.org.tombolo.core.*;
+import uk.org.tombolo.core.utils.SubjectTypeUtils;
+import uk.org.tombolo.core.utils.SubjectUtils;
+import uk.org.tombolo.importer.ons.AbstractONSImporter;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class AbstractOaImporterTest extends AbstractTest {
+    AbstractImporterTest importer = new AbstractImporterTest();
+
+    private class AbstractImporterTest extends AbstractOaImporter {
+
+        @Override
+        protected void importDatasource(Datasource datasource, List<String> geographyScope, List<String> temporalScope, List<String> datasourceLocation) throws Exception {
+
+        }
+
+        @Override
+        public Provider getProvider() {
+            return TestFactory.DEFAULT_PROVIDER;
+        }
+
+        @Override
+        public DatasourceSpec getDatasourceSpec(String datasourceId) throws Exception {
+            return new DatasourceSpec(this.getClass(), "testDatasourceId", "", "", "");
+        }
+
+        @Override
+        public List<String> getDatasourceIds() {
+            return Collections.singletonList("testDatasourceId");
+        }
+
+        @Override
+        protected List<String> getOaDatasourceIds() {
+            return Collections.singletonList("localAuthority");
+        }
+    }
+
+    @Before
+    public void setup() throws Exception {
+        mockDownloadUtils(importer);
+    }
+
+    @Test
+    public void getOaDatasourceIdsCounts() throws Exception {
+        importer.importDatasource("testDatasourceId", Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+
+        //Test the importer imports only the subjects from OaImporter
+        SubjectType subjectType = SubjectTypeUtils.getSubjectTypeByProviderAndLabel(AbstractONSImporter.PROVIDER.getLabel()
+                , "localAuthority");
+        List<Subject> subjects = SubjectUtils.getSubjectByTypeAndLabelPattern(subjectType, "%");
+        assertEquals(7, subjects.size());
+
+        assertEquals(0, importer.getTimedValueCount());
+        assertEquals(0, importer.getSubjectCount());
+        assertEquals(0, importer.getFixedValueCount());
+    }
+}

--- a/src/test/java/uk/org/tombolo/importer/dclg/IMDImporterTest.java
+++ b/src/test/java/uk/org/tombolo/importer/dclg/IMDImporterTest.java
@@ -10,6 +10,7 @@ import uk.org.tombolo.core.Subject;
 import uk.org.tombolo.core.utils.AttributeUtils;
 import uk.org.tombolo.core.utils.TimedValueUtils;
 
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -22,13 +23,22 @@ import static org.junit.Assert.assertEquals;
  * Local file: 30313bb6-b3eb-3ea4-9cea-95e04b25cc4f.csv
  */
 public class IMDImporterTest extends AbstractTest {
-    IMDImporter imdImporter = new IMDImporter();
+    //Create this private class to avoid importing the oa data that slows down the test
+    private class ImporterTest extends IMDImporter {
+        @Override
+        protected List<String> getOaDatasourceIds() {
+            return Collections.emptyList();
+        }
+    }
+
+    IMDImporter imdImporter;
 
     Subject subject1;
     Subject subject2;
 
     @Before
     public void setUp() throws Exception {
+        imdImporter = new ImporterTest();
         imdImporter.setDownloadUtils(makeTestDownloadUtils());
 
         subject1 = TestFactory.makeNamedSubject("E01000001");

--- a/src/test/java/uk/org/tombolo/importer/dft/AccessibilityImporterTest.java
+++ b/src/test/java/uk/org/tombolo/importer/dft/AccessibilityImporterTest.java
@@ -13,6 +13,7 @@ import uk.org.tombolo.core.utils.TimedValueUtils;
 
 import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -22,28 +23,28 @@ import static org.junit.Assert.assertEquals;
  * Using the following test data files:
  *
  * Remote: https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/357458/acs0501.xls
- * Local: aHR0cHM6Ly93d3cuZ292LnVrL2dvdmVybm1lbnQvdXBsb2Fkcy9zeXN0ZW0vdXBsb2Fkcy9hdHRhY2htZW50X2RhdGEvZmlsZS8zNTc0NTgvYWNzMDUwMS54bHM=.xls
+ * Local: a3faf937-48bb-36b4-8958-dd9a709fc9d3.xls
  *
  * Remote: https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/357460/acs0502.xls
- * Local: aHR0cHM6Ly93d3cuZ292LnVrL2dvdmVybm1lbnQvdXBsb2Fkcy9zeXN0ZW0vdXBsb2Fkcy9hdHRhY2htZW50X2RhdGEvZmlsZS8zNTc0NjAvYWNzMDUwMi54bHM=.xls
+ * Local: 76b20598-45e0-3a6f-a9e1-3f73aaff0074.xls
  *
  * Remote: https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/357461/acs0503.xls
- * Local: aHR0cHM6Ly93d3cuZ292LnVrL2dvdmVybm1lbnQvdXBsb2Fkcy9zeXN0ZW0vdXBsb2Fkcy9hdHRhY2htZW50X2RhdGEvZmlsZS8zNTc0NjEvYWNzMDUwMy54bHM=.xls
+ * Local: c41f2008-202b-38a1-adf1-0524cc4ae41c.xls
  *
  * Remote: https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/357464/acs0504.xls
- * Local: aHR0cHM6Ly93d3cuZ292LnVrL2dvdmVybm1lbnQvdXBsb2Fkcy9zeXN0ZW0vdXBsb2Fkcy9hdHRhY2htZW50X2RhdGEvZmlsZS8zNTc0NjQvYWNzMDUwNC54bHM=.xls
+ * Local: b35edb6f-be66-35cd-89e4-6b37681334cb.xls
  *
  * Remote: https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/357467/acs0505.xls
- * Local: aHR0cHM6Ly93d3cuZ292LnVrL2dvdmVybm1lbnQvdXBsb2Fkcy9zeXN0ZW0vdXBsb2Fkcy9hdHRhY2htZW50X2RhdGEvZmlsZS8zNTc0NjcvYWNzMDUwNS54bHM=.xls
+ * Local: 7616e60e-b597-3fa6-92eb-6c77c72184bf.xls
  *
  * Remote: https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/357468/acs0506.xls
  * Local: aHR0cHM6Ly93d3cuZ292LnVrL2dvdmVybm1lbnQvdXBsb2Fkcy9zeXN0ZW0vdXBsb2Fkcy9hdHRhY2htZW50X2RhdGEvZmlsZS8zNTc0NjgvYWNzMDUwNi54bHM=.xls
  *
  * Remote: https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/357469/acs0507.xls
- * Local: aHR0cHM6Ly93d3cuZ292LnVrL2dvdmVybm1lbnQvdXBsb2Fkcy9zeXN0ZW0vdXBsb2Fkcy9hdHRhY2htZW50X2RhdGEvZmlsZS8zNTc0NjkvYWNzMDUwNy54bHM=.xls
+ * Local: ad79ebbb3-339b-34cd-807b-00350da67033.xls
  *
  * Remote: https://www.gov.uk/government/uploads/system/uploads/attachment_data/file/357467/acs0508.xls
- * Local: aHR0cHM6Ly93d3cuZ292LnVrL2dvdmVybm1lbnQvdXBsb2Fkcy9zeXN0ZW0vdXBsb2Fkcy9hdHRhY2htZW50X2RhdGEvZmlsZS8zNTc0NjcvYWNzMDUwOC54bHM=.xls
+ * Local: 767f0676-d56b-3d2f-ab29-754898185b8e.xls
  *
  */
 public class AccessibilityImporterTest extends AbstractTest {
@@ -52,11 +53,18 @@ public class AccessibilityImporterTest extends AbstractTest {
     private Subject cityofLondon001B;
     private Subject islington015E;
 
+    //Create this private class to avoid importing the oa data that slows down the test
+    private class ImporterTest extends AccessibilityImporter {
+        @Override
+        protected List<String> getOaDatasourceIds() {
+            return Collections.emptyList();
+        }
+    }
+
     @Before
     public void setUp() throws Exception {
-        importer = new AccessibilityImporter();
+        importer = new ImporterTest();
         importer.setDownloadUtils(makeTestDownloadUtils());
-
         cityofLondon001A = TestFactory.makeNamedSubject("E01000001");
         cityofLondon001B = TestFactory.makeNamedSubject("E01000002");
         islington015E = TestFactory.makeNamedSubject("E01002766");

--- a/src/test/java/uk/org/tombolo/importer/londondatastore/AbstractLondonDatastoreTestUtil.java
+++ b/src/test/java/uk/org/tombolo/importer/londondatastore/AbstractLondonDatastoreTestUtil.java
@@ -7,6 +7,7 @@ import uk.org.tombolo.core.Subject;
 
 public abstract class AbstractLondonDatastoreTestUtil extends AbstractTest {
 
+
     Subject cityOfLondon;
     Subject islington;
 

--- a/src/test/java/uk/org/tombolo/importer/londondatastore/AdultObesityImporterTest.java
+++ b/src/test/java/uk/org/tombolo/importer/londondatastore/AdultObesityImporterTest.java
@@ -8,6 +8,7 @@ import uk.org.tombolo.core.TimedValue;
 import uk.org.tombolo.core.utils.AttributeUtils;
 import uk.org.tombolo.core.utils.TimedValueUtils;
 
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -16,8 +17,16 @@ import static org.junit.Assert.assertEquals;
  * This test is using data from 0bf8b2be-3dca-3512-8f8d-48bdb704eb3c.xls
  */
 public class AdultObesityImporterTest extends AbstractLondonDatastoreTestUtil {
+    //Create this private class to avoid importing the oa data that slows down the test
+    private class ImporterTest extends AdultObesityImporter {
+        @Override
+        protected List<String> getOaDatasourceIds() {
+
+            return Collections.emptyList();
+        }
+    }
     static final private String DATASOURCE_ID = "adultObesity";
-    private AdultObesityImporter importer = new AdultObesityImporter();
+    private AdultObesityImporter importer = new ImporterTest();
 
     @Before
     public void setUp() throws Exception {

--- a/src/test/java/uk/org/tombolo/importer/londondatastore/LondonPHOFImporterTest.java
+++ b/src/test/java/uk/org/tombolo/importer/londondatastore/LondonPHOFImporterTest.java
@@ -8,6 +8,7 @@ import uk.org.tombolo.core.TimedValue;
 import uk.org.tombolo.core.utils.AttributeUtils;
 import uk.org.tombolo.core.utils.TimedValueUtils;
 
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -18,12 +19,21 @@ import static org.junit.Assert.assertEquals;
  * Local: cd309e6a-a89a-3906-9e7a-26f750dce624.xlsx
  */
 public class LondonPHOFImporterTest extends AbstractLondonDatastoreTestUtil {
+	//Create this private class to avoid importing the oa data that slows down the test
+	private class ImporterTest extends LondonPHOFImporter {
+		@Override
+		protected List<String> getOaDatasourceIds() {
+
+			return Collections.emptyList();
+		}
+	}
+
 	private static final String DATASOURCE_ID = "phofIndicatorsLondonBorough";
 	private LondonPHOFImporter importer;
 
 	@Before
 	public void before(){
-		importer = new LondonPHOFImporter();
+		importer = new ImporterTest();
 		mockDownloadUtils(importer);
 	}
 

--- a/src/test/java/uk/org/tombolo/importer/londondatastore/WalkingCyclingBoroughImporterTest.java
+++ b/src/test/java/uk/org/tombolo/importer/londondatastore/WalkingCyclingBoroughImporterTest.java
@@ -10,6 +10,7 @@ import uk.org.tombolo.core.utils.TimedValueUtils;
 
 import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
@@ -20,12 +21,21 @@ import static org.junit.Assert.assertEquals;
  *  Local: 9a21e9c1-c776-3b25-9db5-9b4d7dc7f248.xls
  */
 public class WalkingCyclingBoroughImporterTest extends AbstractLondonDatastoreTestUtil {
+	//Create this private class to avoid importing the oa data that slows down the test
+	private class ImporterTest extends WalkingCyclingBoroughImporter {
+		@Override
+		protected List<String> getOaDatasourceIds() {
+
+			return Collections.emptyList();
+		}
+	}
+
 	private static final String DATASOURCE_ID = "walkingCyclingBorough";
 	public WalkingCyclingBoroughImporter importer;
 
 	@Before
 	public void before(){
-		importer = new WalkingCyclingBoroughImporter();
+		importer = new ImporterTest();
 		mockDownloadUtils(importer);
 	};
 

--- a/src/test/java/uk/org/tombolo/importer/ons/CensusImporterTest.java
+++ b/src/test/java/uk/org/tombolo/importer/ons/CensusImporterTest.java
@@ -73,7 +73,7 @@ public class CensusImporterTest extends AbstractTest {
         importer.importDatasource(MTW_ID, null, null, null, subjectRecipes, false);
         assertEquals(0, importer.getSubjectCount());
         assertEquals(0, importer.getFixedValueCount());
-        assertEquals(78, importer.getTimedValueCount());
+        assertEquals(52, importer.getTimedValueCount());
 
         Attribute attribute01 = AttributeUtils.getByProviderAndLabel(importer.getProvider(),
                 "Method of Travel to Work: All categories: Method of travel to work");
@@ -111,7 +111,7 @@ public class CensusImporterTest extends AbstractTest {
         importer.importDatasource(POP_ID, null, null, null, subjectRecipes, false);
         assertEquals(0, importer.getSubjectCount());
         assertEquals(0, importer.getFixedValueCount());
-        assertEquals(18, importer.getTimedValueCount());
+        assertEquals(12, importer.getTimedValueCount());
 
         Attribute attribute01 = AttributeUtils.getByProviderAndLabel(importer.getProvider(),
                 "Area/Population Density: Density (number of persons per hectare)");
@@ -134,7 +134,7 @@ public class CensusImporterTest extends AbstractTest {
         importer.importDatasource(POD_ID, null, null, null, subjectRecipes, false);
         assertEquals(0, importer.getSubjectCount());
         assertEquals(0, importer.getFixedValueCount());
-        assertEquals(24, importer.getTimedValueCount());
+        assertEquals(16, importer.getTimedValueCount());
 
         Attribute attribute01 = AttributeUtils.getByProviderAndLabel(importer.getProvider(),
                 "Disability: Day-to-day activities limited a little");

--- a/src/test/java/uk/org/tombolo/importer/ons/CensusImporterTest.java
+++ b/src/test/java/uk/org/tombolo/importer/ons/CensusImporterTest.java
@@ -33,6 +33,7 @@ public class CensusImporterTest extends AbstractTest {
     @Before
     public void setup() throws Exception {
         importer = new CensusImporter();
+        importer.setSubjectRecipes(subjectRecipes);
         mockDownloadUtils(importer);
 
         cityOfLondon01 = TestFactory.makeNamedSubject("E01000001");
@@ -43,37 +44,37 @@ public class CensusImporterTest extends AbstractTest {
 
     @Test
     public void getTimedValueAttributesMTW() throws Exception {
-        importer.importDatasource(MTW_ID, null, null, null, subjectRecipes, false);
+        importer.importDatasource(MTW_ID, null, null, null, false);
         List<Attribute> attributes = importer.getTimedValueAttributes(MTW_ID);
         assertEquals(13, attributes.size());
     }
 
     @Test
     public void getTimedValueAttributesPOP() throws Exception {
-        importer.importDatasource(POP_ID, null, null, null, subjectRecipes, false);
+        importer.importDatasource(POP_ID, null, null, null, false);
         List<Attribute> attributes = importer.getTimedValueAttributes(POP_ID);
         assertEquals(3, attributes.size());
     }
 
     @Test
     public void getTimedValueAttributesPOD() throws Exception {
-        importer.importDatasource(POD_ID, null, null, null, subjectRecipes, false);
+        importer.importDatasource(POD_ID, null, null, null, false);
         List<Attribute> attributes = importer.getTimedValueAttributes(POD_ID);
         assertEquals(4, attributes.size());
     }
 
     @Test
     public void getDataUrl() throws Exception {
-        importer.importDatasource(MTW_ID, null, null, null, subjectRecipes, false);
+        importer.importDatasource(MTW_ID, null, null, null, false);
         assertEquals("https://www.nomisweb.co.uk/api/v01/dataset/nm_568_1.bulk.csv?time=latest&measures=20100&rural_urban=total&geography=TYPE298", importer.getDataUrl(MTW_ID, "lsoa"));
     }
 
     @Test
     public void importDatasourceMTW() throws Exception {
-        importer.importDatasource(MTW_ID, null, null, null, subjectRecipes, false);
+        importer.importDatasource(MTW_ID, null, null, null, false);
         assertEquals(0, importer.getSubjectCount());
         assertEquals(0, importer.getFixedValueCount());
-        assertEquals(52, importer.getTimedValueCount());
+        assertEquals(78, importer.getTimedValueCount());
 
         Attribute attribute01 = AttributeUtils.getByProviderAndLabel(importer.getProvider(),
                 "Method of Travel to Work: All categories: Method of travel to work");
@@ -108,10 +109,10 @@ public class CensusImporterTest extends AbstractTest {
 
     @Test
     public void importDatasourcePOP() throws Exception {
-        importer.importDatasource(POP_ID, null, null, null, subjectRecipes, false);
+        importer.importDatasource(POP_ID, null, null, null, false);
         assertEquals(0, importer.getSubjectCount());
         assertEquals(0, importer.getFixedValueCount());
-        assertEquals(12, importer.getTimedValueCount());
+        assertEquals(18, importer.getTimedValueCount());
 
         Attribute attribute01 = AttributeUtils.getByProviderAndLabel(importer.getProvider(),
                 "Area/Population Density: Density (number of persons per hectare)");
@@ -131,10 +132,10 @@ public class CensusImporterTest extends AbstractTest {
 
     @Test
     public void importDatasourcePOD() throws Exception {
-        importer.importDatasource(POD_ID, null, null, null, subjectRecipes, false);
+        importer.importDatasource(POD_ID, null, null, null, false);
         assertEquals(0, importer.getSubjectCount());
         assertEquals(0, importer.getFixedValueCount());
-        assertEquals(16, importer.getTimedValueCount());
+        assertEquals(24, importer.getTimedValueCount());
 
         Attribute attribute01 = AttributeUtils.getByProviderAndLabel(importer.getProvider(),
                 "Disability: Day-to-day activities limited a little");

--- a/src/test/java/uk/org/tombolo/importer/phe/AdultObesityImporterTest.java
+++ b/src/test/java/uk/org/tombolo/importer/phe/AdultObesityImporterTest.java
@@ -11,6 +11,7 @@ import uk.org.tombolo.core.TimedValue;
 import uk.org.tombolo.core.utils.AttributeUtils;
 import uk.org.tombolo.core.utils.TimedValueUtils;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -24,15 +25,23 @@ import static org.junit.Assert.assertEquals;
  * Local: 1a02e39e-59ac-3c05-a11e-51d0bbb58a0f.xlsx
  */
 public class AdultObesityImporterTest extends AbstractTest {
+	//Create this private class to avoid importing the oa data that slows down the test
+	private class ImporterTest extends AdultObesityImporter {
+		@Override
+		protected List<String> getOaDatasourceIds() {
+
+			return Collections.emptyList();
+		}
+	}
 	private static final String DATASOURCE_ID = "adultObesity";
-	private AdultObesityImporter importer = new AdultObesityImporter();
+	private AdultObesityImporter importer = new ImporterTest();
 
 	private Subject cityOfLondon;
-
 	@Before
 	public void addSubjectFixtures() {
 		cityOfLondon = TestFactory.makeNamedSubject("E09000001");
 	}
+
 
 	@Before
 	public void setDownloadUtils() {

--- a/src/test/java/uk/org/tombolo/lac/LAQNImporterTest.java
+++ b/src/test/java/uk/org/tombolo/lac/LAQNImporterTest.java
@@ -19,6 +19,8 @@ import static org.junit.Assert.assertEquals;
 
 /**
  * LAQNImporterTest file
+ *
+ * Local: ea9b6d00-1ba7-3e41-90aa-ed292b195569.json
  */
 public class LAQNImporterTest extends AbstractTest {
 


### PR DESCRIPTION
### Description
Fixes the bug of `datasourceId` not recognised when importing `OaImporter` subjects inside other importers. This PR fixes the bug but also adds support for a different scenario not included in the master atm.
In the current status an importer that uses existing subjects defined in `OaImporter` would import them internally even if not defined as datasources in the recipe. This will happen only if the `OaImporter` subject type they need is a top level subject in the recipe. This means that if the top subject is `lsoa` and the importer needs existing `msoa` subjects, they will not be imported. This PR takes care also of the latter.


Fixes #458

