### PR TITLE
extended match rule functionality

### DIFF
--- a/src/main/java/uk/org/tombolo/recipe/SubjectRecipe.java
+++ b/src/main/java/uk/org/tombolo/recipe/SubjectRecipe.java
@@ -6,12 +6,15 @@ public class SubjectRecipe {
 
 	public static class SubjectAttributeMatchRule {
 		public enum MatchableAttribute {label, name};
+		public enum MatchableType {contains, startsWith, endsWith, equals};
 		public final MatchableAttribute attribute;
-		public final String pattern;
+		public final MatchableType filter;
+		public final String value;
 
-		public SubjectAttributeMatchRule(MatchableAttribute attribute, String pattern) {
+		public SubjectAttributeMatchRule(MatchableAttribute attribute, MatchableType filter, String value) {
 			this.attribute = attribute;
-			this.pattern = pattern;
+			this.filter = filter;
+			this.value = value;
 		}
 	}
 

--- a/src/main/resources/data_export_specification_schema.json
+++ b/src/main/resources/data_export_specification_schema.json
@@ -23,13 +23,18 @@
                     "type": "string",
                     "enum": ["label", "name"]
                   },
-                  "pattern": {
+                  "filter": {
+                    "type": "string",
+                    "enum": ["contains", "startsWith", "endsWith", "equals"]
+                  },
+                  "value": {
                     "type": "string"
                   }
                 },
                 "required": [
                   "attribute",
-                  "pattern"
+                  "filter",
+                  "value"
                 ],
                 "additionalProperties": false
               },

--- a/src/main/resources/executions/examples/aggregate-traffic-count-data-within-localauthorities.json
+++ b/src/main/resources/executions/examples/aggregate-traffic-count-data-within-localauthorities.json
@@ -8,7 +8,8 @@
         "provider":"uk.gov.ons",
         "matchRule": {
           "attribute": "label",
-          "pattern": "E090%"
+          "filter": "startsWith",
+          "value": "E090"
         }
       }
     ],

--- a/src/main/resources/executions/examples/birmingham-land-use-variance.json
+++ b/src/main/resources/executions/examples/birmingham-land-use-variance.json
@@ -6,7 +6,8 @@
         "subjectType": "msoa",
         "matchRule": {
           "attribute": "name",
-          "pattern": "Birmingham%"
+          "filter": "startsWith",
+          "value": "Birmingham"
         }
       }
     ],

--- a/src/main/resources/executions/examples/get-localauthority-data-for-traffic-counters.json
+++ b/src/main/resources/executions/examples/get-localauthority-data-for-traffic-counters.json
@@ -13,7 +13,8 @@
               "provider": "uk.gov.ons",
               "matchRule": {
                 "attribute": "label",
-                "pattern": "E090%"
+                "filter": "startsWith",
+                "value": "E090"
               }
             }
           ]

--- a/src/main/resources/executions/examples/greenspace-hertfordshire.json
+++ b/src/main/resources/executions/examples/greenspace-hertfordshire.json
@@ -7,7 +7,8 @@
         "subjectType": "lsoa",
         "matchRule": {
           "attribute": "name",
-          "pattern": "St Albans%"
+          "filter": "startsWith",
+          "value": "St Albans"
         }
       }
     ],

--- a/src/main/resources/executions/examples/islington-active-transport-index.json
+++ b/src/main/resources/executions/examples/islington-active-transport-index.json
@@ -6,7 +6,8 @@
         "subjectType": "lsoa",
         "matchRule": {
           "attribute": "name",
-          "pattern": "Islington%"
+          "filter": "startsWith",
+          "value": "Islington"
         }
       }
     ],

--- a/src/main/resources/executions/examples/leeds-activetravel-greenspace-ratio.json
+++ b/src/main/resources/executions/examples/leeds-activetravel-greenspace-ratio.json
@@ -6,7 +6,8 @@
         "subjectType" : "lsoa",
         "matchRule": {
           "attribute": "name",
-          "pattern": "Leeds%"
+          "filter": "startsWith",
+          "value": "Leeds"
         }
       }
     ],

--- a/src/main/resources/executions/examples/leisure-park-hertfordshire.json
+++ b/src/main/resources/executions/examples/leisure-park-hertfordshire.json
@@ -7,7 +7,8 @@
         "subjectType": "lsoa",
         "matchRule": {
           "attribute": "name",
-          "pattern": "St Albans%"
+          "filter": "startsWith",
+          "value": "St Albans"
         }
       }
     ],

--- a/src/main/resources/executions/examples/london-cycle-traffic-air-quality-lsoa-backoff.json
+++ b/src/main/resources/executions/examples/london-cycle-traffic-air-quality-lsoa-backoff.json
@@ -12,7 +12,8 @@
               "provider": "uk.gov.ons",
               "matchRule": {
                 "attribute": "label",
-                "pattern": "E090%"
+                "filter": "startsWith",
+                "value": "E090"
               }
             }
           ]

--- a/src/main/resources/executions/examples/london-cycle-traffic-air-quality-lsoa-modelling.json
+++ b/src/main/resources/executions/examples/london-cycle-traffic-air-quality-lsoa-modelling.json
@@ -12,7 +12,8 @@
               "provider": "uk.gov.ons",
               "matchRule": {
                 "attribute": "label",
-                "pattern": "E090%"
+                "filter": "startsWith",
+                "value": "E090"
               }
             }
           ]

--- a/src/main/resources/executions/examples/london-cycle-traffic-air-quality-lsoa.json
+++ b/src/main/resources/executions/examples/london-cycle-traffic-air-quality-lsoa.json
@@ -12,7 +12,8 @@
               "provider": "uk.gov.ons",
               "matchRule": {
                 "attribute": "label",
-                "pattern": "E090%"
+                "filter": "startsWith",
+                "value": "E090"
               }
             }
           ]

--- a/src/main/resources/executions/examples/london-cycle-traffic-air-quality-meanvalue.json
+++ b/src/main/resources/executions/examples/london-cycle-traffic-air-quality-meanvalue.json
@@ -22,7 +22,8 @@
           "provider": "uk.gov.ons",
           "matchRule": {
             "attribute": "label",
-            "pattern": "E090%"
+            "filter": "startsWith",
+            "value": "E090"
           }
         }
       ],

--- a/src/main/resources/executions/examples/london-cycle-traffic-air-quality.json
+++ b/src/main/resources/executions/examples/london-cycle-traffic-air-quality.json
@@ -6,7 +6,8 @@
         "provider": "uk.gov.ons",
         "matchRule": {
           "attribute": "label",
-          "pattern": "E090%"
+          "filter": "startsWith",
+          "value": "E090"
         }
       }
     ],

--- a/src/main/resources/executions/examples/map-to-nearest-subject.json
+++ b/src/main/resources/executions/examples/map-to-nearest-subject.json
@@ -15,7 +15,8 @@
               "provider": "uk.gov.ons",
               "matchRule": {
                 "attribute": "label",
-                "pattern": "E090%"
+                "filter": "startsWith",
+                "value": "E090"
               }
             }
           ]

--- a/src/main/resources/executions/examples/reaggregate-traffic-count-to-la.json
+++ b/src/main/resources/executions/examples/reaggregate-traffic-count-to-la.json
@@ -13,7 +13,8 @@
               "provider": "uk.gov.ons",
               "matchRule": {
                 "attribute": "label",
-                "pattern": "E090%"
+                "filter": "startsWith",
+                "value": "E090"
               }
             }
           ]

--- a/src/main/resources/executions/examples/renting-percentiles-for-leeds-normalised-nationally.json
+++ b/src/main/resources/executions/examples/renting-percentiles-for-leeds-normalised-nationally.json
@@ -7,7 +7,8 @@
         "provider": "uk.gov.ons",
         "matchRule": {
           "attribute": "name",
-          "pattern": "Leeds%"
+          "filter": "startsWith",
+          "value": "Leeds"
         }
       }
     ],

--- a/src/main/resources/executions/examples/restricting-subjects-to-geography.json
+++ b/src/main/resources/executions/examples/restricting-subjects-to-geography.json
@@ -14,7 +14,8 @@
               "provider": "uk.gov.ons",
               "matchRule": {
                 "attribute": "name",
-                "pattern": "Greenwich"
+                "filter": "equals",
+                "value": "Greenwich"
               }
             },
             {
@@ -22,7 +23,8 @@
               "provider": "uk.gov.ons",
               "matchRule": {
                 "attribute": "name",
-                "pattern": "Islington"
+                "filter": "equals",
+                "value": "Islington"
               }
             }
           ]

--- a/src/main/resources/executions/examples/social-isolation-leeds.json
+++ b/src/main/resources/executions/examples/social-isolation-leeds.json
@@ -6,7 +6,8 @@
         "subjectType": "lsoa",
         "matchRule": {
           "attribute": "name",
-          "pattern": "Leeds%"
+          "filter": "startsWith",
+          "value": "Leeds"
         }
       }
     ],

--- a/src/main/resources/executions/examples/social-resilience-leeds.json
+++ b/src/main/resources/executions/examples/social-resilience-leeds.json
@@ -7,7 +7,8 @@
         "provider": "uk.gov.ons",
         "matchRule": {
           "attribute": "name",
-          "pattern": "Leeds%"
+          "filter": "startsWith",
+          "value": "Leeds"
         }
       }
     ],

--- a/src/main/resources/executions/examples/traffic-counts-geography-scope.json
+++ b/src/main/resources/executions/examples/traffic-counts-geography-scope.json
@@ -13,7 +13,8 @@
               "provider": "uk.gov.ons",
               "matchRule": {
                 "attribute": "label",
-                "pattern": "E090%"
+                "filter": "startsWith",
+                "value": "E090"
               }
             }
           ]

--- a/src/main/resources/executions/examples/tweet-number-person-number-compare.json
+++ b/src/main/resources/executions/examples/tweet-number-person-number-compare.json
@@ -8,7 +8,8 @@
         "provider": "uk.gov.ons",
         "matchRule": {
           "attribute": "label",
-          "pattern": "E090%"
+          "filter": "startsWith",
+          "value": "E090"
         }
       }
     ],

--- a/src/test/java/uk/org/tombolo/DataExportEngineTest.java
+++ b/src/test/java/uk/org/tombolo/DataExportEngineTest.java
@@ -59,7 +59,7 @@ public class DataExportEngineTest extends AbstractTest {
     @Test
     public void testReturnsSubject() throws Exception {
         builder.addSubjectSpecification(
-                new SubjectSpecificationBuilder(AbstractONSImporter.PROVIDER.getLabel(),"lsoa").setMatcher("label", "E01000001")
+                new SubjectSpecificationBuilder(AbstractONSImporter.PROVIDER.getLabel(),"lsoa").setMatcher("label", "equals", "E01000001")
         );
 
         engine.execute(builder.build(), writer, emptyImporterMatcher);
@@ -72,7 +72,7 @@ public class DataExportEngineTest extends AbstractTest {
         DatabaseJournal.addJournalEntry(new DatabaseJournalEntry("uk.org.tombolo.importer.ons.OaImporter", "localAuthority"));
 
         builder.addSubjectSpecification(
-                new SubjectSpecificationBuilder(AbstractONSImporter.PROVIDER.getLabel(), "localAuthority").setMatcher("label", "E10000006")
+                new SubjectSpecificationBuilder(AbstractONSImporter.PROVIDER.getLabel(), "localAuthority").setMatcher("label", "equals", "E10000006")
         ).addDatasourceSpecification("uk.org.tombolo.importer.ons.OaImporter", "localAuthority", null);
         engine.execute(builder.build(), writer, emptyImporterMatcher);
 
@@ -86,7 +86,7 @@ public class DataExportEngineTest extends AbstractTest {
         DatabaseJournal.addJournalEntry(new DatabaseJournalEntry("uk.org.tombolo.importer.ons.OaImporter", "localAuthority"));
 
         builder.addSubjectSpecification(
-                new SubjectSpecificationBuilder(AbstractONSImporter.PROVIDER.getLabel(), "localAuthority").setMatcher("label", "E06000001")
+                new SubjectSpecificationBuilder(AbstractONSImporter.PROVIDER.getLabel(), "localAuthority").setMatcher("label", "equals", "E06000001")
         ).addDatasourceSpecification("uk.org.tombolo.importer.ons.OaImporter", "localAuthority", "");
 
         // And we set the clear-database flag
@@ -109,7 +109,7 @@ public class DataExportEngineTest extends AbstractTest {
         TestFactory.makeTimedValue(lsoa, "E01000001", attribute, "2011-01-01T00:00:00", 100d);
 
         builder.addSubjectSpecification(
-                new SubjectSpecificationBuilder(AbstractONSImporter.PROVIDER.getLabel(), "lsoa").setMatcher("label", "E01000001")
+                new SubjectSpecificationBuilder(AbstractONSImporter.PROVIDER.getLabel(), "lsoa").setMatcher("label", "equals", "E01000001")
         ).addFieldSpecification(
                 FieldBuilder.wrapperField("attributes", Arrays.asList(
                         FieldBuilder.latestValue("default_provider_label", "attr_label")
@@ -142,7 +142,7 @@ public class DataExportEngineTest extends AbstractTest {
         TestFactory.makeTimedValue(lsoa, "E01000001", attribute, "2011-01-01T00:00", 100d);
 
         builder.addSubjectSpecification(
-                new SubjectSpecificationBuilder(AbstractONSImporter.PROVIDER.getLabel(), "lsoa").setMatcher("label", "E01000001")
+                new SubjectSpecificationBuilder(AbstractONSImporter.PROVIDER.getLabel(), "lsoa").setMatcher("label", "equals", "E01000001")
         ).addFieldSpecification(
                 FieldBuilder.wrapperField("attributes", Arrays.asList(
                         FieldBuilder.valuesByTime("default_provider_label", "attr_label")
@@ -173,7 +173,7 @@ public class DataExportEngineTest extends AbstractTest {
     @Test
     public void testImportsFromLondonDataStore() throws Exception {
         builder.addSubjectSpecification(
-                new SubjectSpecificationBuilder(AbstractONSImporter.PROVIDER.getLabel(), "localAuthority").setMatcher("label", "E09000001"))
+                new SubjectSpecificationBuilder(AbstractONSImporter.PROVIDER.getLabel(), "localAuthority").setMatcher("label", "equals", "E09000001"))
                 .addDatasourceSpecification("uk.org.tombolo.importer.londondatastore.LondonBoroughProfileImporter", "londonBoroughProfiles", "")
                 .addFieldSpecification(
                         FieldBuilder.wrapperField("attributes", Arrays.asList(
@@ -205,7 +205,7 @@ public class DataExportEngineTest extends AbstractTest {
     @Test
     public void testTransforms() throws Exception {
         builder .addSubjectSpecification(
-                        new SubjectSpecificationBuilder(AbstractONSImporter.PROVIDER.getLabel(), "lsoa").setMatcher("label", "E01002766"))
+                        new SubjectSpecificationBuilder(AbstractONSImporter.PROVIDER.getLabel(), "lsoa").setMatcher("label", "equals", "E01002766"))
                 .addDatasourceSpecification("uk.org.tombolo.importer.ons.CensusImporter", "qs103ew", "")
                 .addFieldSpecification(
                         FieldBuilder.wrapperField("attributes", Arrays.asList(
@@ -239,7 +239,7 @@ public class DataExportEngineTest extends AbstractTest {
     public void testRunsOnNewSubjects() throws Exception {
         builder
             .addSubjectSpecification(
-                new SubjectSpecificationBuilder(AbstractONSImporter.PROVIDER.getLabel(), "localAuthority").setMatcher("label", "E06000001"))
+                new SubjectSpecificationBuilder(AbstractONSImporter.PROVIDER.getLabel(), "localAuthority").setMatcher("label", "equals", "E06000001"))
             .addDatasourceSpecification("uk.org.tombolo.importer.ons.OaImporter", "localAuthority", "")
             .addDatasourceSpecification("uk.org.tombolo.importer.londondatastore.LondonBoroughProfileImporter", "londonBoroughProfiles", "")
             .addFieldSpecification(
@@ -276,7 +276,7 @@ public class DataExportEngineTest extends AbstractTest {
         TestFactory.makeTimedValue(localAuthority, "E09000001", attribute, "2011-01-01T00:00:00", 100d);
 
         builder.addSubjectSpecification(
-                new SubjectSpecificationBuilder(AbstractONSImporter.PROVIDER.getLabel(), "lsoa").setMatcher("label", "E01000001")
+                new SubjectSpecificationBuilder(AbstractONSImporter.PROVIDER.getLabel(), "lsoa").setMatcher("label", "equals", "E01000001")
         ).addFieldSpecification(
                 FieldBuilder.mapToContainingSubjectField(
                         "local_authority",
@@ -319,7 +319,7 @@ public class DataExportEngineTest extends AbstractTest {
         TestFactory.makeTimedValue(lsoa, "E01000002", attribute, "2011-01-01T00:00:00", 110d);
 
         builder.addSubjectSpecification(
-                new SubjectSpecificationBuilder(AbstractONSImporter.PROVIDER.getLabel(), "localAuthority").setMatcher("label", "E09000001")
+                new SubjectSpecificationBuilder(AbstractONSImporter.PROVIDER.getLabel(), "localAuthority").setMatcher("label", "equals", "E09000001")
         ).addFieldSpecification(
                 FieldBuilder.geographicAggregation(
                         "local_authority",
@@ -347,7 +347,7 @@ public class DataExportEngineTest extends AbstractTest {
         DataExportSpecificationBuilder csvBuilder = DataExportSpecificationBuilder.withCSVExporter();
         csvBuilder
                 .addSubjectSpecification(
-                        new SubjectSpecificationBuilder(AbstractONSImporter.PROVIDER.getLabel(), "lsoa").setMatcher("label", "E01002766"))
+                        new SubjectSpecificationBuilder(AbstractONSImporter.PROVIDER.getLabel(), "lsoa").setMatcher("label", "equals", "E01002766"))
                 .addDatasourceSpecification("uk.org.tombolo.importer.ons.CensusImporter", "qs103ew", "")
                 .addFieldSpecification(
                         FieldBuilder.fractionOfTotal("percentage_under_1_years_old_label")
@@ -372,9 +372,9 @@ public class DataExportEngineTest extends AbstractTest {
     @Ignore
     public void testExportsMultipleSubjectTypes() throws Exception {
         builder .addSubjectSpecification(
-                new SubjectSpecificationBuilder(AbstractONSImporter.PROVIDER.getLabel(), "lsoa").setMatcher("label", "E01002766"))
+                new SubjectSpecificationBuilder(AbstractONSImporter.PROVIDER.getLabel(), "lsoa").setMatcher("label", "equals", "E01002766"))
                 .addSubjectSpecification(
-                        new SubjectSpecificationBuilder(AbstractONSImporter.PROVIDER.getLabel(), "localAuthority").setMatcher("label", "E08000035"))
+                        new SubjectSpecificationBuilder(AbstractONSImporter.PROVIDER.getLabel(), "localAuthority").setMatcher("label", "equals", "E08000035"))
                 .addDatasourceSpecification("uk.org.tombolo.importer.ons.CensusImporter", "qs103ew", "")
                 .addFieldSpecification(
                         FieldBuilder.wrapperField("attributes", Arrays.asList(
@@ -422,7 +422,7 @@ public class DataExportEngineTest extends AbstractTest {
     @Test
     public void testGeneratesModellingField() throws Exception {
         builder.addSubjectSpecification(
-                new SubjectSpecificationBuilder(AbstractONSImporter.PROVIDER.getLabel(), "lsoa").setMatcher("label", "E01002766")
+                new SubjectSpecificationBuilder(AbstractONSImporter.PROVIDER.getLabel(), "lsoa").setMatcher("label", "equals", "E01002766")
         ).addFieldSpecification(
                 FieldBuilder.modellingField("aLabel", "ModellingFieldTest")
         );
@@ -446,7 +446,7 @@ public class DataExportEngineTest extends AbstractTest {
     @Test
     public void testGeneratesModellingFieldWhenNested() throws Exception {
         builder.addSubjectSpecification(
-                new SubjectSpecificationBuilder(AbstractONSImporter.PROVIDER.getLabel(), "lsoa").setMatcher("label", "E01002766")
+                new SubjectSpecificationBuilder(AbstractONSImporter.PROVIDER.getLabel(), "lsoa").setMatcher("label", "equals", "E01002766")
         ).addFieldSpecification(
                 FieldBuilder.wrapperField("aWrapper", Collections.singletonList(
                     FieldBuilder.modellingField("aLabel", "ModellingFieldTest")))
@@ -473,12 +473,12 @@ public class DataExportEngineTest extends AbstractTest {
     @Test
     public void testExportsPercentiles() throws Exception {
         builder .addSubjectSpecification(
-                new SubjectSpecificationBuilder(AbstractONSImporter.PROVIDER.getLabel(), "lsoa").setMatcher("label", "E0100276_"))
+                new SubjectSpecificationBuilder(AbstractONSImporter.PROVIDER.getLabel(), "lsoa").setMatcher("label", "equals", "E0100276_"))
                 .addDatasourceSpecification("uk.org.tombolo.importer.ons.CensusImporter", "qs103ew", "")
                 .addFieldSpecification(
                         FieldBuilder.percentilesField("quartile", 4, false)
                                 .set("valueField", FieldBuilder.latestValue("uk.gov.ons", "Age: All categories: Age")) // total population
-                                .set("normalizationSubjects", Collections.singletonList(new SubjectSpecificationBuilder(AbstractONSImporter.PROVIDER.getLabel(), "lsoa").setMatcher("label", "E0100276_")))
+                                .set("normalizationSubjects", Collections.singletonList(new SubjectSpecificationBuilder(AbstractONSImporter.PROVIDER.getLabel(), "lsoa").setMatcher("label", "equals", "E0100276_")))
                 );
 
         engine.execute(builder.build(), writer, emptyImporterMatcher);

--- a/src/test/java/uk/org/tombolo/SubjectSpecificationBuilder.java
+++ b/src/test/java/uk/org/tombolo/SubjectSpecificationBuilder.java
@@ -13,10 +13,11 @@ public class SubjectSpecificationBuilder implements JSONAware {
         jsonSpec.put("subjectType", subjectType);
     }
 
-    public SubjectSpecificationBuilder setMatcher(String attribute, String pattern) {
+    public SubjectSpecificationBuilder setMatcher(String attribute, String filter, String value) {
         JSONObject matchRule = new JSONObject();
         matchRule.put("attribute", attribute);
-        matchRule.put("pattern", pattern);
+        matchRule.put("filter", filter);
+        matchRule.put("value", value);
         jsonSpec.put("matchRule", matchRule);
         return this;
     }

--- a/src/test/java/uk/org/tombolo/core/utils/SpatialJoinTest.java
+++ b/src/test/java/uk/org/tombolo/core/utils/SpatialJoinTest.java
@@ -36,7 +36,7 @@ public class SpatialJoinTest extends AbstractTest {
 
         SubjectSpecificationBuilder parentSpec = new SubjectSpecificationBuilder(
                 TestFactory.DEFAULT_PROVIDER.getLabel(), subjectType1.getLabel())
-                .setMatcher("label", subject1.getLabel());
+                .setMatcher("label", "equals", subject1.getLabel());
         List<SubjectSpecificationBuilder> parentSpecs = new ArrayList<>();
         parentSpecs.add(parentSpec);
 

--- a/src/test/java/uk/org/tombolo/core/utils/SubjectUtilsTest.java
+++ b/src/test/java/uk/org/tombolo/core/utils/SubjectUtilsTest.java
@@ -140,7 +140,7 @@ public class SubjectUtilsTest extends AbstractTest {
 	@Test
 	public void testGetSubjectBySpecificationLabelSearch() throws Exception {
 		DatasetRecipe spec = DataExportSpecificationBuilder.withCSVExporter().addSubjectSpecification(
-				new SubjectSpecificationBuilder(AbstractONSImporter.PROVIDER.getLabel(), "localAuthority").setMatcher("label", "E09%")
+				new SubjectSpecificationBuilder(AbstractONSImporter.PROVIDER.getLabel(), "localAuthority").setMatcher("label", "startsWith", "E09%")
 		).build().getDataset();
 		List<Subject> subjects = SubjectUtils.getSubjectBySpecification(spec);
 		assertTrue("Label " + subjects.get(0).getLabel() + " matches searched pattern E09%", subjects.get(0).getLabel().contains("E09"));
@@ -149,7 +149,7 @@ public class SubjectUtilsTest extends AbstractTest {
 	@Test
 	public void testGetSubjectBySpecificationNameSearch() throws Exception {
 		DatasetRecipe spec = DataExportSpecificationBuilder.withCSVExporter().addSubjectSpecification(
-				new SubjectSpecificationBuilder(AbstractONSImporter.PROVIDER.getLabel(), "localAuthority").setMatcher("name", "%don")
+				new SubjectSpecificationBuilder(AbstractONSImporter.PROVIDER.getLabel(), "localAuthority").setMatcher("name", "endsWith", "%don")
 		).build().getDataset();
 		List<Subject> subjects = SubjectUtils.getSubjectBySpecification(spec);
 		assertTrue("Name " + subjects.get(0).getName() + " matches searched pattern %don", subjects.get(0).getName().contains("don"));
@@ -158,7 +158,7 @@ public class SubjectUtilsTest extends AbstractTest {
 	@Test
 	public void testGetSubjectBySpecificationWithSubject() throws Exception {
 		SubjectRecipe spec = DataExportSpecificationBuilder.withCSVExporter().addSubjectSpecification(
-				new SubjectSpecificationBuilder(AbstractONSImporter.PROVIDER.getLabel(), "localAuthority").setMatcher("name", "%don")
+				new SubjectSpecificationBuilder(AbstractONSImporter.PROVIDER.getLabel(), "localAuthority").setMatcher("name", "endsWith", "%don")
 		).build().getDataset().getSubjects().get(0);
 		List<Subject> subjects = SubjectUtils.getSubjectBySpecification(spec);
 		assertTrue("Name " + subjects.get(0).getName() + " matches searched pattern %don", subjects.get(0).getName().contains("don"));
@@ -185,7 +185,7 @@ public class SubjectUtilsTest extends AbstractTest {
 
 		// Testing sensors inside Square One
 		SubjectSpecificationBuilder squareOneSpec =
-				new SubjectSpecificationBuilder(TestFactory.DEFAULT_PROVIDER.getLabel(), squareAuthority.getLabel()).setMatcher("name",squareOne.getName());
+				new SubjectSpecificationBuilder(TestFactory.DEFAULT_PROVIDER.getLabel(), squareAuthority.getLabel()).setMatcher("name", "equals", squareOne.getName());
 		List<SubjectSpecificationBuilder> parentSpecs = new ArrayList<>();
 		parentSpecs.add(squareOneSpec);
 		SubjectRecipe childSpec = DataExportSpecificationBuilder.withCSVExporter().addSubjectSpecification(
@@ -198,7 +198,7 @@ public class SubjectUtilsTest extends AbstractTest {
 
 		// Testing sensors inside Square One and Two
 		SubjectSpecificationBuilder squareTwoSpec =
-				new SubjectSpecificationBuilder(TestFactory.DEFAULT_PROVIDER.getLabel(), squareAuthority.getLabel()).setMatcher("label",squareTwo.getLabel());
+				new SubjectSpecificationBuilder(TestFactory.DEFAULT_PROVIDER.getLabel(), squareAuthority.getLabel()).setMatcher("label", "equals", squareTwo.getLabel());
 		parentSpecs.add(squareTwoSpec);
 		childSpec = DataExportSpecificationBuilder.withCSVExporter().addSubjectSpecification(
 				new SubjectSpecificationBuilder(TestFactory.DEFAULT_PROVIDER.getLabel(), pointSensor.getLabel()).setGeoMatcher("within", parentSpecs)

--- a/src/test/java/uk/org/tombolo/recipe/DataExportRecipeValidatorTest.java
+++ b/src/test/java/uk/org/tombolo/recipe/DataExportRecipeValidatorTest.java
@@ -24,9 +24,9 @@ public class DataExportRecipeValidatorTest extends AbstractTest {
     @Test
     public void testValidateWithValidBuilder() throws Exception {
         DataExportSpecificationBuilder spec = DataExportSpecificationBuilder.withGeoJsonExporter().addSubjectSpecification(
-                new SubjectSpecificationBuilder("uk.gov.ons", "lsoa").setMatcher("label", "E01002766"))
+                new SubjectSpecificationBuilder("uk.gov.ons", "lsoa").setMatcher("label", "equals", "E01002766"))
                 .addSubjectSpecification(
-                        new SubjectSpecificationBuilder("uk.gov.ons", "localAuthority").setMatcher("label", "E08000035"))
+                        new SubjectSpecificationBuilder("uk.gov.ons", "localAuthority").setMatcher("label", "equals", "E08000035"))
                 .addDatasourceSpecification("uk.org.tombolo.importer.ons.CensusImporter", "qs103ew", "")
                 .addFieldSpecification(
                         FieldBuilder.wrapperField("attributes", Arrays.asList(

--- a/src/test/resources/executions/valid_specification_file.json
+++ b/src/test/resources/executions/valid_specification_file.json
@@ -3,14 +3,16 @@
     "subjects": [{
       "provider":"uk.gov.ons",
       "matchRule": {
-        "pattern": "E01002766",
+        "value": "E01002766",
+        "filter": "equals",
         "attribute": "label"
       },
       "subjectType": "lsoa"
     }, {
       "provider":"uk.gov.ons",
       "matchRule": {
-        "pattern": "E08000035",
+        "value": "E08000035",
+        "filter": "equals",
         "attribute": "label"
       },
       "subjectType": "localAuthority"


### PR DESCRIPTION
### Description

This PR aims at fixing #268 . In current implementation in order to match a pattern user needs to provide something like this ```E090%``` to search for areas in London which is not very intuitive. I n this PR it is changed to more intuitive approach, please see below for eg.

Current Approach
```
"matchRule" : {
    "attribute" : "label",
    "pattern" : "E090%"
}
```

Approach Proposed in PR:
```
        "matchRule": {
          "attribute": "label",
          "filter": "startsWith",
          "value": "E090"
        }
```

### Checklist
NA
