### PR TITLE
added batch size to hibernate

### DIFF
--- a/src/main/java/uk/org/tombolo/core/utils/FixedValueUtils.java
+++ b/src/main/java/uk/org/tombolo/core/utils/FixedValueUtils.java
@@ -41,8 +41,7 @@ public class FixedValueUtils {
                             fixedValue.getId().getAttribute().getLabel(),
                             e.getMessage());
                 }
-                if ( saved % 20 == 0 ) { //20, same as the JDBC batch size
-                    //flush a batch of inserts and release memory:
+                if ( saved % 50 == 0 ) { // because batch size in the hibernate config is 50
                     session.flush();
                     session.clear();
                 }
@@ -73,11 +72,7 @@ public class FixedValueUtils {
                             fixedValue.getId().getAttribute().getLabel(),
                             e.getMessage());
                 }
-                if ( saved % 2000 == 0 ) { 
-                    // FIXME:
-					// Flushing at small intervals increase overhead for the system to clear the session.
-					// The default behaviour of hibernate is to auto flush when it thinks is necessary thus it may be required to 
-					// flush the session manually but this requires testing, and can be cosidered as fixme
+                if ( saved % 50 == 0 ) { 
                     session.flush();
                     session.clear();
                 }

--- a/src/main/java/uk/org/tombolo/core/utils/SubjectUtils.java
+++ b/src/main/java/uk/org/tombolo/core/utils/SubjectUtils.java
@@ -116,8 +116,7 @@ public class SubjectUtils {
 				}
 				saved++;
 
-				if ( saved % 20 == 0 ) { //20, same as the JDBC batch size
-					//flush a batch of inserts and release memory:
+				if ( saved % 50 == 0 ) { // because batch size in the hibernate config is 50
 					session.flush();
 					session.clear();
 				}
@@ -145,11 +144,7 @@ public class SubjectUtils {
                     log.warn("Could not save subject {}, name {},", subject.getLabel(), subject.getName());
                 }
 
-				if ( saved % 2000 == 0 ) {
-					// FIXME:
-					// Flushing at small intervals increase overhead for the system to clear the session.
-					// The default behaviour of hibernate is to auto flush when it thinks is necessary thus it may be required to 
-					// flush the session manually but this requires testing, and can be cosidered as fixme 
+				if ( saved % 50 == 0 ) {
 					session.flush();
 					session.clear();
 				}

--- a/src/main/java/uk/org/tombolo/core/utils/TimedValueUtils.java
+++ b/src/main/java/uk/org/tombolo/core/utils/TimedValueUtils.java
@@ -112,8 +112,7 @@ public class TimedValueUtils {
 							timedValue.getId().getTimestamp().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
 							e.getMessage());
 				}
-				if ( saved % 20 == 0 ) { //20, same as the JDBC batch size
-					//flush a batch of inserts and release memory:
+				if ( saved % 50 == 0 ) { // because batch size in the hibernate config is 50
 					session.flush();
 					session.clear();
 				}
@@ -145,11 +144,7 @@ public class TimedValueUtils {
 							timedValue.getId().getTimestamp().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
 							e.getMessage());
 				}
-				if ( saved % 2000 == 0 ) { 
-					// FIXME:
-					// Flushing at small intervals increase overhead for the system to clear the session.
-					// The default behaviour of hibernate is to auto flush when it thinks is necessary thus it may be required to 
-					// flush the session manually but this requires testing, and can be cosidered as fixme
+				if ( saved % 50 == 0 ) { 
 					session.flush();
 					session.clear();
 				}

--- a/src/main/resources/hibernate.cfg.xml
+++ b/src/main/resources/hibernate.cfg.xml
@@ -15,6 +15,7 @@
         <property name="hibernate.cache.use_second_level_cache">true</property>
         <property name="hibernate.cache.provider_class">org.hibernate.cache.EhCacheProvider</property>
         <property name="hibernate.cache.region.factory_class">org.hibernate.cache.ehcache.EhCacheRegionFactory</property>
+        <property name="hibernate.jdbc.batch_size">50</property>
 
         <property name="show_sql">false</property>
 


### PR DESCRIPTION
### Description

Currently DC doesn't have any minimum batch size limit, which means that every time database tries to save anything it creates a batch size of 5 records, which makes the saving operation slow.

This PR addresses that issue and puts a batch size of 50. Have tested this by running various recipes and they all showed performance improvements and were 3-4 times faster.

### Checklist

- [ ] Created new test(s) (if applicable)
- [ ] Updated the README / documentation (if applicable)
