### PR TITLE
Change decimal precision for geometry from default 4 to 8 (mm)

### DIFF
--- a/src/main/java/uk/org/tombolo/exporter/GeoJsonExporter.java
+++ b/src/main/java/uk/org/tombolo/exporter/GeoJsonExporter.java
@@ -76,6 +76,7 @@ public class GeoJsonExporter implements Exporter {
 	}
 
 	private String getGeoJSONGeometryForSubject(Subject subject) {
-		return (new GeometryJSON()).toString(subject.getShape());
+		// For millimeter (mm) precision represent lat/lon with 8 decimal places in decimal degrees format.
+		return (new GeometryJSON(8)).toString(subject.getShape());
 	}
 }


### PR DESCRIPTION
Fixes #469

### Description
After some investigation and excluding through testing a possible bug in osm4j found out that OSM geometries (geometries in general) in output from the DC are rounded to 4 decimals which is the default one from `GeometryJSON()`.
```
package org.geotools.geojson.geom;

    /**
     * Constructs a geometry json instance.
     */
    public GeometryJSON() {
        this(4);
    }
```
This rounding would cause discrepancies between the original geometry and the one produced by DC. In this PR it's changed to 8 for millimeter (mm) precision representing lat/lon with 8 decimal places in decimal degrees format.

To test it for the review overlap the 2 layers of osm original and output of the DC in QGIS. If they match the issue should be solved. Testing with different geometry types would be awesome 💃 

### Checklist

- [ ] ~~Created new test(s) (if applicable)~~
- [ ] ~~Updated the README / documentation (if applicable)~~
